### PR TITLE
Perfv1

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -27,13 +27,16 @@ Notes / assumptions:
    Missing values (NA, ".", "") -> coverage 0 (uncovered).
  - If your real files use a different format, adjust parse_allele_entry accordingly.
 """
+import logging
 import os
-import re
 import math
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import lru_cache
 import numpy as np
 import pandas as pd
 from typing import Tuple, Optional, Dict, Any
-from src.reproducibility import set_seed, deterministic_permutation
+
+logger = logging.getLogger(__name__)
 
 # -------------------------
 # Low-level parsing helpers
@@ -52,6 +55,62 @@ def _is_float_string(s: str) -> bool:
     except Exception:
         return False
 
+def _parse_alt_total_pair(left: str, right: str) -> Tuple[Optional[int], Optional[int], Optional[float]]:
+    if _is_integer_string(left) and _is_integer_string(right):
+        alt = int(left)
+        total = int(right)
+        if total >= alt and total >= 0:
+            ref = total - alt
+            maf = alt / total if total > 0 else 0.0
+            return ref, alt, maf
+        return None, None, None
+
+    if _is_float_string(left) and _is_float_string(right):
+        alt = float(left)
+        total = float(right)
+        if total >= alt and total >= 0:
+            ref = total - alt
+            maf = alt / total if total > 0 else 0.0
+            return int(round(ref)), int(round(alt)), maf
+        return None, None, None
+
+    return None, None, None
+
+@lru_cache(maxsize=65536)
+def _parse_allele_string(s: str) -> Tuple[Optional[int], Optional[int], Optional[float]]:
+    s = s.strip()
+    if not s:
+        return None, None, None
+
+    lowered = s.lower()
+    if s == "." or lowered == "na" or lowered == "nan":
+        return None, None, None
+
+    for sep in ["/", ":", ",", "|", ";"]:
+        if sep in s:
+            left, _, right = s.partition(sep)
+            if left and right:
+                parsed = _parse_alt_total_pair(left.strip(), right.strip())
+                if parsed != (None, None, None):
+                    return parsed
+
+    parts = s.split()
+    if len(parts) >= 2:
+        parsed = _parse_alt_total_pair(parts[0], parts[1])
+        if parsed != (None, None, None):
+            return parsed
+
+    if _is_integer_string(s):
+        return int(s), None, None
+
+    if _is_float_string(s):
+        val = float(s)
+        if 0.0 <= val <= 1.0:
+            return None, None, float(val)
+        return int(round(val)), None, None
+
+    return None, None, None
+
 def parse_allele_entry(entry: Any) -> Tuple[Optional[int], Optional[int], Optional[float]]:
     """
     Parse one cell x mutation entry from allele count matrix.
@@ -62,53 +121,11 @@ def parse_allele_entry(entry: Any) -> Tuple[Optional[int], Optional[int], Option
       - if NA or '.', return (None, None, None) and caller will set coverage=0
     Supported separators: ':', ',', '/', '|', ';', whitespace
     """
-    if pd.isna(entry):
+    if entry is None or entry is pd.NA:
         return None, None, None
-    s = str(entry).strip()
-    if s == "" or s == "." or s.lower() == "nan":
+    if isinstance(entry, float) and math.isnan(entry):
         return None, None, None
-    
-    # Try common two-number separators (alt/total format)
-    for sep in [":", ",", "/", "|", ";", " "]:
-        if sep in s:
-            parts = [p for p in re.split(re.escape(sep), s) if p != ""]
-            if len(parts) >= 2:
-                # try parse as alt/total format (VCF style)
-                a, b = parts[0], parts[1]
-                if _is_integer_string(a) and _is_integer_string(b):
-                    alt = int(a)
-                    total = int(b)
-                    if total >= alt and total >= 0:
-                        ref = total - alt
-                        maf = alt / total if total > 0 else 0.0
-                        return ref, alt, maf
-                    else:
-                        return None, None, None
-                # allow floats too
-                if _is_float_string(a) and _is_float_string(b):
-                    alt = float(a)
-                    total = float(b)
-                    if total >= alt and total >= 0:
-                        ref = total - alt
-                        maf = alt / total if total > 0 else 0.0
-                        return int(round(ref)), int(round(alt)), maf
-                    else:
-                        return None, None, None
-    
-    # Single integer: treat as coverage
-    if _is_integer_string(s):
-        return int(s), None, None
-    
-    # Single float: treat as MAF
-    if _is_float_string(s):
-        val = float(s)
-        if 0.0 <= val <= 1.0:
-            return None, None, float(val)
-        else:
-            # If outside 0-1 range, treat as coverage
-            return int(round(val)), None, None
-    
-    return None, None, None
+    return _parse_allele_string(str(entry))
 
 # -------------------------
 # Loaders
@@ -162,7 +179,59 @@ def load_reads(reads_path: str) -> pd.DataFrame:
     df = pd.read_csv(reads_path, sep="\t", index_col=0, dtype=str)
     return df.T
 
-def derive_MCA_from_reads(df_reads: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def _resolve_load_workers(num_workers: Optional[int], num_columns: int) -> int:
+    if num_columns <= 1:
+        return 1
+
+    if num_workers is not None:
+        requested = int(num_workers)
+        if requested > 0:
+            return min(requested, num_columns)
+
+    cpu_count = os.cpu_count() or 1
+    if cpu_count <= 1 or num_columns < 8:
+        return 1
+    return min(num_columns, min(cpu_count, 8))
+
+def _parse_reads_block(values: np.ndarray, start_col: int, end_col: int) -> Tuple[int, np.ndarray, np.ndarray, np.ndarray]:
+    row_count = values.shape[0]
+    width = end_col - start_col
+    v_block = np.full((row_count, width), np.nan, dtype=float)
+    c_block = np.zeros((row_count, width), dtype=np.int32)
+    a_block = np.zeros((row_count, width), dtype=np.int32)
+
+    for local_col, col_idx in enumerate(range(start_col, end_col)):
+        v_col = v_block[:, local_col]
+        c_col = c_block[:, local_col]
+        a_col = a_block[:, local_col]
+
+        for row_idx, entry in enumerate(values[:, col_idx]):
+            ref, alt, maf = parse_allele_entry(entry)
+
+            if ref is None and alt is None:
+                if maf is not None:
+                    v_col[row_idx] = float(maf)
+                    c_col[row_idx] = 1
+                    a_col[row_idx] = int(round(maf))
+                continue
+
+            if ref is not None and alt is not None:
+                total = ref + alt
+                if total > 0:
+                    v_col[row_idx] = alt / total
+                    c_col[row_idx] = total
+                    a_col[row_idx] = alt
+                continue
+
+            if ref is not None:
+                c_col[row_idx] = int(ref)
+
+    return start_col, v_block, c_block, a_block
+
+def derive_MCA_from_reads(
+    df_reads: pd.DataFrame,
+    num_workers: Optional[int] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     输入: df_reads (cells x muts)，每个元素可能是:
       - "alt:total", "alt/total", "alt,total" 等 (alt/total格式)
@@ -176,57 +245,46 @@ def derive_MCA_from_reads(df_reads: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Data
     """
     cells = df_reads.index
     muts = df_reads.columns
-    V = pd.DataFrame(index=cells, columns=muts, dtype=float)
-    C = pd.DataFrame(index=cells, columns=muts, dtype=int)
-    A = pd.DataFrame(index=cells, columns=muts, dtype=int)
-    
-    for i in cells:
-        for j in muts:
-            entry = df_reads.at[i, j]
-            ref, alt, maf = parse_allele_entry(entry)
-            
-            if ref is None and alt is None and maf is None:
-                # uncovered
-                V.at[i, j] = np.nan
-                C.at[i, j] = 0
-                A.at[i, j] = 0
-            
-            elif maf is not None and ref is None and alt is None:
-                # direct maf
-                V.at[i, j] = float(maf)
-                C.at[i, j] = 1
-                A.at[i, j] = int(round(maf))
-            
-            elif ref is not None and alt is not None:
-                # alt/total format: ref = total - alt, alt = alt
-                total = ref + alt
-                if total == 0:
-                    V.at[i, j] = np.nan
-                    C.at[i, j] = 0
-                    A.at[i, j] = 0
-                else:
-                    V.at[i, j] = alt / total
-                    C.at[i, j] = total
-                    A.at[i, j] = alt
-            
-            elif ref is not None and alt is None:
-                # only coverage (total)
-                C.at[i, j] = int(ref)
-                V.at[i, j] = np.nan
-                A.at[i, j] = 0
-            
-            else:
-                # fallback
-                C.at[i, j] = 0
-                V.at[i, j] = np.nan
-                A.at[i, j] = 0
-    
+    values = df_reads.to_numpy(dtype=object, copy=False)
+    worker_count = _resolve_load_workers(num_workers, len(muts))
+
+    if worker_count == 1:
+        blocks = [_parse_reads_block(values, 0, len(muts))]
+    else:
+        chunk_size = math.ceil(len(muts) / worker_count)
+        ranges = [
+            (start_col, min(start_col + chunk_size, len(muts)))
+            for start_col in range(0, len(muts), chunk_size)
+        ]
+        logger.info(
+            "Parsing allele count matrix with %d worker threads across %d mutation columns",
+            worker_count,
+            len(muts),
+        )
+        blocks = []
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = [
+                executor.submit(_parse_reads_block, values, start_col, end_col)
+                for start_col, end_col in ranges
+            ]
+            for future in as_completed(futures):
+                blocks.append(future.result())
+
+        blocks.sort(key=lambda item: item[0])
+
+    v_values = np.concatenate([block[1] for block in blocks], axis=1)
+    c_values = np.concatenate([block[2] for block in blocks], axis=1)
+    a_values = np.concatenate([block[3] for block in blocks], axis=1)
+
+    V = pd.DataFrame(v_values, index=cells, columns=muts)
+    C = pd.DataFrame(c_values, index=cells, columns=muts)
+    A = pd.DataFrame(a_values, index=cells, columns=muts)
     return V, C, A
 
 # -------------------------
 # High level loader
 # -------------------------
-def load_all(inputpath: str) -> Dict[str, pd.DataFrame]:
+def load_all(inputpath: str, load_workers: Optional[int] = None) -> Dict[str, pd.DataFrame]:
     """
     Read the standard set of input files from a directory (matching your example):
       - data.posterior_matrix.txt
@@ -247,7 +305,10 @@ def load_all(inputpath: str) -> Dict[str, pd.DataFrame]:
     
     P = load_posterior(files['posterior'])
     df_reads = load_reads(files['reads'])
-    V, C, A = derive_MCA_from_reads(df_reads)
+    V, C, A = derive_MCA_from_reads(df_reads, num_workers=load_workers)
+    V_raw_reads = V.copy()
+    C_raw_reads = C.copy()
+    A_raw_reads = A.copy()
     features = load_features(files['features'])
     ll_mut = load_likelihoods(files['ll_mut'])
     ll_unmut = load_likelihoods(files['ll_unmut'])
@@ -276,6 +337,9 @@ def load_all(inputpath: str) -> Dict[str, pd.DataFrame]:
         "V": V,
         "A": A,
         "C": C,
+        "V_raw_reads": V_raw_reads,
+        "A_raw_reads": A_raw_reads,
+        "C_raw_reads": C_raw_reads,
         "df_reads": df_reads,
         "features": features,
         "ll_mut": ll_mut,
@@ -294,10 +358,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--inputpath", default="./data", type=str)
     parser.add_argument("-o", "--outputpath", default="./results", type=str)
+    parser.add_argument("--load_workers", default=None, type=int)
     args = parser.parse_args()
     
     print(f"Loading from: {args.inputpath}")
-    out = load_all(args.inputpath)
+    out = load_all(args.inputpath, load_workers=args.load_workers)
     print("Loaded matrices:")
     for k, v in out.items():
         if isinstance(v, pd.DataFrame):

--- a/src/mutation_integrator.py
+++ b/src/mutation_integrator.py
@@ -68,6 +68,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+_VERBOSE_TREE_UPDATES = os.environ.get("PHYLOSOLID_VERBOSE_TREES", "").lower() in {"1", "true", "yes", "on"}
 
 # Default parameters matching Methods Section 3
 DEFAULT_PARAMS = {
@@ -166,6 +167,40 @@ def count_conditions(I_attached_col, M_current_col):
         'count_na_1': count_na_1,
         'count_na_0': count_na_0
     }
+
+
+def as_binary_mask(series, index):
+    """
+    Normalize a Series-like vector to an aligned boolean mask.
+    """
+    aligned = pd.Series(series, index=index) if not isinstance(series, pd.Series) else series.reindex(index)
+    values = aligned.to_numpy(copy=False)
+
+    if np.issubdtype(values.dtype, np.bool_):
+        return pd.Series(values, index=index, copy=False)
+
+    if np.issubdtype(values.dtype, np.integer):
+        return pd.Series(values > 0, index=index)
+
+    if np.issubdtype(values.dtype, np.floating):
+        mask = np.isfinite(values) & (values > 0)
+        return pd.Series(mask, index=index)
+
+    numeric = pd.to_numeric(aligned, errors="coerce")
+    numeric_values = numeric.to_numpy(dtype=np.float64, na_value=np.nan)
+    mask = np.isfinite(numeric_values) & (numeric_values > 0)
+    return pd.Series(mask, index=index)
+
+
+def _coerce_bool_array(series, index):
+    return series.reindex(index, fill_value=0).fillna(0).to_numpy(dtype=bool, copy=False)
+
+
+def _log_tree_snapshot(active_logger, label, tree):
+    if not _VERBOSE_TREE_UPDATES:
+        return
+    active_logger.info(label)
+    print_tree(tree)
 
 
 
@@ -795,63 +830,72 @@ def merge_mutations(M_current_each_mut, all_nodes_in_T_scaffold):
 # 配置日志
 logger = logging.getLogger(__name__)
 
-def find_intersection_positions_within_tree_directly(T_current: TreeNode, new_mut: str, matrix, min_overlap=1):
+def find_intersection_positions_within_tree_directly(
+    T_current: TreeNode,
+    new_mut: str,
+    matrix,
+    min_overlap=1,
+    intersection_nodes=None,
+    tree_parent_dict=None,
+    node_lookup=None,
+):
     """
     基于交集分析的优化版本，直接找到相关位置
     """
     # 1. 找到所有与目标突变有交集的节点
-    intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(
-        T_current, matrix, new_mut, min_overlap
-    )
+    if intersection_nodes is None:
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(
+            T_current, matrix, new_mut, min_overlap
+        )
     
-    logger.info(f"Found {len(intersection_nodes)} intersection nodes for {new_mut}: {intersection_nodes}")
+    logger.debug("Found %s intersection nodes for %s: %s", len(intersection_nodes), new_mut, intersection_nodes)
     
     if len(intersection_nodes) == 0:
         logger.debug(f"No intersection nodes found for {new_mut}")
         return []  # 没有交集，返回空列表
     
     # 2. 构建树的父子关系字典
-    tree_parent_dict = build_tree_parent_dict(T_current)
+    if tree_parent_dict is None:
+        tree_parent_dict = build_tree_parent_dict(T_current)
     
     # 3. 找到所有相关路径上的节点
     all_path_nodes = find_all_path_nodes(intersection_nodes, tree_parent_dict)
     
-    logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut}")
+    logger.debug("Found %s path nodes for %s", len(all_path_nodes), new_mut)
     
-    # 4. 预先创建基础树的深拷贝
-    base_tree_copy = deepcopy(T_current)
-    
-    # 5. 只在这些相关节点上生成候选位置
+    # 4. 只在这些相关节点上生成候选位置
     candidate_positions = []
+    if node_lookup is None:
+        node_lookup = {node.name: node for node in T_current.traverse()}
     
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             # 保留 ROOT 上的 on_node 类型的 position
-            node = base_tree_copy.find(node_name)
+            node = node_lookup.get(node_name)
             if node is None:
                 logger.warning(f"Node {node_name} not found in tree")
                 continue
             
             # 生成 ROOT 上的 on_node 类型的候选位置
-            candidate_positions.append(_create_on_node_candidate_fast(base_tree_copy, node, new_mut))
+            candidate_positions.append(_create_on_node_candidate_fast(node, new_mut))
             
             continue  # ROOT 的其他类型位置仍然跳过
         
-        node = base_tree_copy.find(node_name)
+        node = node_lookup.get(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
         
         # --- 1) 放在 node 上 ---
-        candidate_positions.append(_create_on_node_candidate_fast(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_on_node_candidate_fast(node, new_mut))
         
         # --- 2) 新 leaf ---
-        candidate_positions.append(_create_new_leaf_candidate_fast(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_new_leaf_candidate_fast(node, new_mut))
         
         # --- 3) 放在每条 edge 上 ---
         for child in node.children:
             if child.name in all_path_nodes:  # 只考虑路径上的子节点
-                candidate_positions.append(_create_on_edge_candidate_fast(base_tree_copy, node, child, new_mut))
+                candidate_positions.append(_create_on_edge_candidate_fast(node, child, new_mut))
         
         # --- 4) 新 parent merge 多个子节点 ---
         if len(node.children) >= 2:
@@ -861,9 +905,9 @@ def find_intersection_positions_within_tree_directly(T_current: TreeNode, new_mu
                 # 限制组合数量避免爆炸
                 for r in range(2, min(4, len(path_children) + 1)):
                     for combo in combinations(path_children, r):
-                        candidate_positions.append(_create_merge_candidate_fast(base_tree_copy, node, combo, new_mut))
+                        candidate_positions.append(_create_merge_candidate_fast(node, combo, new_mut))
     
-    logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
+    logger.debug("Generated %s candidate positions for %s", len(candidate_positions), new_mut)
     return candidate_positions
 
 
@@ -876,101 +920,47 @@ def build_tree_parent_dict(tree):
     return parent_dict
 
 
-def _create_on_node_candidate_fast(base_tree_copy, node, new_mut):
+def _create_on_node_candidate_fast(node, new_mut):
     """快速创建放在节点上的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    anchor_node = new_tree.find(node.name)
-    
-    # 替换节点逻辑
-    new_node = TreeNode(new_mut)
-    for child in anchor_node.children:
-        new_node.add_child(deepcopy(child))
-    
-    if anchor_node.parent:
-        parent = anchor_node.parent
-        for i, child in enumerate(parent.children):
-            if child.name == node.name:
-                parent.children[i] = new_node
-                new_node.parent = parent
-                break
-    else:
-        new_tree = new_node
-    
     return {
         "placement_type": "on_node",
         "anchor": node.name,
         "meta": {},
-        "nodes": _extract_nodes_info(new_tree),
-        "edges": _extract_edges_info(new_tree)
+        "sibling_nodes": [],
     }
 
 
-def _create_new_leaf_candidate_fast(base_tree_copy, node, new_mut):
+def _create_new_leaf_candidate_fast(node, new_mut):
     """快速创建新叶子的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    anchor_node = new_tree.find(node.name)
-    new_leaf = TreeNode(new_mut)
-    anchor_node.add_child(new_leaf)
-    
+    child_nodes = [child.name for child in node.children]
     return {
         "placement_type": "new_leaf",
         "anchor": node.name,
         "meta": {},
-        "nodes": _extract_nodes_info(new_tree),
-        "edges": _extract_edges_info(new_tree)
+        "child_nodes": child_nodes,
+        "sibling_nodes": child_nodes,
     }
 
 
-def _create_on_edge_candidate_fast(base_tree_copy, parent_node, child_node, new_mut):
+def _create_on_edge_candidate_fast(parent_node, child_node, new_mut):
     """快速创建放在边上的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    parent = new_tree.find(parent_node.name)
-    child = new_tree.find(child_node.name)
-    new_node = TreeNode(new_mut)
-    parent.remove_child(child)
-    parent.add_child(new_node)
-    new_node.add_child(child)
-    
     return {
         "placement_type": "on_edge",
         "anchor": parent_node.name,
         "meta": {"child": child_node.name},
-        "nodes": _extract_nodes_info(new_tree),
-        "edges": _extract_edges_info(new_tree)
+        "sibling_nodes": [child.name for child in parent_node.children if child.name != child_node.name],
     }
 
 
-def _create_merge_candidate_fast(base_tree_copy, parent_node, children_combo, new_mut):
+def _create_merge_candidate_fast(parent_node, children_combo, new_mut):
     """快速创建合并子节点的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    parent = new_tree.find(parent_node.name)
-    combo_nodes = [new_tree.find(child.name) for child in children_combo]
-    new_parent = TreeNode(new_mut)
-    for cn in combo_nodes:
-        parent.remove_child(cn)
-        new_parent.add_child(cn)
-    parent.add_child(new_parent)
-    
+    merge_children = [child.name for child in children_combo]
     return {
         "placement_type": "new_parent_merge",
         "anchor": parent_node.name,
-        "meta": {"merge_children": [child.name for child in children_combo]},
-        "nodes": _extract_nodes_info(new_tree),
-        "edges": _extract_edges_info(new_tree)
+        "meta": {"merge_children": merge_children},
+        "sibling_nodes": [child.name for child in parent_node.children if child.name not in merge_children],
     }
-
-
-def _extract_nodes_info(tree):
-    """提取节点信息"""
-    return [{"name": n.name,
-             "parent": n.parent.name if n.parent else None,
-             "children": [c.name for c in n.children]} 
-            for n in tree.traverse()]
-
-
-def _extract_edges_info(tree):
-    """提取边信息"""
-    return [(n.parent.name, n.name) for n in tree.traverse() if n.parent]
 
 
 def build_parent_dict_from_candidates(candidate_positions):
@@ -1022,41 +1012,57 @@ def build_parent_dict_from_candidates(candidate_positions):
     
 #     return intersect_muts
 
-def find_all_intersect_muts_from_tree_by_matrix(tree, matrix, target_mut, min_overlap=1):
+def find_all_intersect_muts_from_tree_by_matrix(
+    tree,
+    matrix,
+    target_mut,
+    min_overlap=1,
+    matrix_positive=None,
+    matrix_positive_values=None,
+    matrix_positive_col_to_idx=None,
+    tree_nodes=None,
+    node_to_mutations=None,
+):
     """
     返回所有与 target_mut 在 matrix 中有至少 min_overlap 个细胞共同出现的树节点集合。
     """
     intersect_nodes = set()
-    
-    # 遍历所有节点（除 ROOT）
-    for node in tree.all_nodes():
-        if node.name == "ROOT":
+    if target_mut not in matrix.columns:
+        return intersect_nodes
+
+    if matrix_positive is None and matrix_positive_values is None:
+        matrix_positive = matrix.eq(1).fillna(False)
+    if matrix_positive_values is None:
+        matrix_positive_values = matrix_positive.to_numpy(dtype=bool, copy=False)
+    if matrix_positive_col_to_idx is None:
+        source_columns = matrix_positive.columns if matrix_positive is not None else matrix.columns
+        matrix_positive_col_to_idx = {col: idx for idx, col in enumerate(source_columns)}
+
+    target_idx = matrix_positive_col_to_idx.get(target_mut)
+    if target_idx is None:
+        return intersect_nodes
+
+    target_positive = matrix_positive_values[:, target_idx]
+    if not bool(target_positive.any()):
+        return intersect_nodes
+
+    overlap_counts = matrix_positive_values[target_positive].sum(axis=0, dtype=np.int64)
+    nodes_to_scan = tree_nodes if tree_nodes is not None else tree.all_nodes()
+
+    for node in nodes_to_scan:
+        node_name = node.name if hasattr(node, "name") else node
+        if node_name == "ROOT":
             continue
-        
-        has_intersection = False
-        
-        # 检查节点中的每个突变是否与目标突变有交集
-        for mut in node.name.split("|"):
+
+        mutations_on_node = node_to_mutations.get(node_name, ()) if node_to_mutations is not None else tuple(node_name.split("|"))
+        for mut in mutations_on_node:
             if mut == target_mut:
-                continue  # 跳过自身
-            
-            if mut not in matrix.columns or target_mut not in matrix.columns:
-                continue  # 确保突变存在于矩阵中
-            
-            # 计算两突变的共现数量
-            mut_vec = matrix[mut].fillna(0)
-            target_vec = matrix[target_mut].fillna(0)
-            N11 = ((mut_vec == 1) & (target_vec == 1)).sum()
-            
-            # 如果任何一个突变有足够的共现，就标记这个节点
-            if N11 >= min_overlap:
-                has_intersection = True
-                break  # 只要节点中有一个突变有交集就够了
-        
-        # 如果节点中有任何突变与目标突变有交集，就添加整个节点
-        if has_intersection:
-            intersect_nodes.add(node.name)
-    
+                continue
+            mut_idx = matrix_positive_col_to_idx.get(mut)
+            if mut_idx is not None and int(overlap_counts[mut_idx]) >= min_overlap:
+                intersect_nodes.add(node_name)
+                break
+
     return intersect_nodes
 
 def find_all_path_nodes(intersection_nodes, tree_parent_dict):
@@ -1374,6 +1380,9 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
     import pandas as pd
     import numpy as np
     results = []
+    matrix_index = M_current.index
+    lineage_parent_cache = {}
+    conflict_mask_cache = {}
     
     # 如果没有候选位置，直接返回 None
     if len(selected_positions) == 0:
@@ -1381,6 +1390,34 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         return None, None, pd.DataFrame(), M_current
     
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
+    new_mut_mask = as_binary_mask(new_mut_bin_vector, matrix_index)
+
+    def get_lineage_parent_dict(anchor_name):
+        cached = lineage_parent_cache.get(anchor_name)
+        if cached is None:
+            cached = build_lineage_parent_dict_from_tree(T_current, anchor_name)
+            lineage_parent_cache[anchor_name] = cached
+        return cached
+
+    def get_conflict_nodes(anchor_name, sibling_nodes, exclude_nodes=None):
+        exclude_nodes = tuple(exclude_nodes or ())
+        sibling_key = tuple(sorted(sibling_nodes))
+        cache_key = (anchor_name, sibling_key, exclude_nodes)
+        cached = conflict_mask_cache.get(cache_key)
+        if cached is None:
+            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(
+                anchor_name,
+                get_lineage_parent_dict(anchor_name),
+                M_current.columns,
+                exclude_nodes=list(exclude_nodes),
+            )
+            all_conflict_nodes = tuple(set(sibling_nodes + lineage_conflict_nodes))
+            vec_conflicts = pd.Series(False, index=matrix_index)
+            for conflict in all_conflict_nodes:
+                vec_conflicts |= as_binary_mask(M_current[conflict], matrix_index)
+            cached = (all_conflict_nodes, vec_conflicts)
+            conflict_mask_cache[cache_key] = cached
+        return cached
         
     # 计算突变的特征用于动态调整惩罚
     input_binary_vec_full = I_selected[new_mut].replace({pd.NA: np.nan})
@@ -1391,7 +1428,6 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
     for idx, pos in enumerate(selected_positions):
         placement_type = pos['placement_type']
         anchor = pos['anchor']
-        # N_nodes_beforeT = len([node['name'] for node in pos['nodes']])
         
         # 默认 imputed vector
         imputed_vec = pd.Series(0, index=M_current.index)
@@ -1405,21 +1441,11 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
             vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent'] == parent and n['name'] != new_mut]
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] != new_mut])
+            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
             
             # 正确的逻辑：现有节点的向量与清理后的new_mut合并
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (M_current[anchor] | new_mut_cleaned).astype(int)
             N_nodes = N_nodes_beforeT + 1
             
@@ -1428,21 +1454,11 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
             vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent'] == parent and n['name'] != new_mut]
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] != new_mut])
+            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
             
             # 正确的逻辑：先排除所有冲突，再与parent交集
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = new_mut_cleaned.astype(int)
             N_nodes = N_nodes_beforeT + 2
             
@@ -1453,21 +1469,11 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
             vec_child = M_current[child]
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in [child,new_mut]]
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] not in [child, new_mut]])
+            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
             
             # 正确的逻辑：child ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (vec_child | new_mut_cleaned).astype(int)
             N_nodes = N_nodes_beforeT + 2
             
@@ -1482,21 +1488,11 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
                 vec_children |= M_current[c]
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in merge_children+[new_mut]]
-            
-            # 获取lineage之外的所有冲突节点（排除merge_children）
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns, exclude_nodes=merge_children)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] not in merge_children + [new_mut]])
+            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes, exclude_nodes=merge_children)
             
             # 正确的逻辑：children ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (vec_children | new_mut_cleaned).astype(int)
             merge_penalty = np.log(len(merge_children)) * 0.5
             N_nodes = N_nodes_beforeT + 2
@@ -2847,7 +2843,17 @@ def get_mutation_clone_and_backbone_node_as_keys_by_first_level(root: TreeNode) 
     return clone_dict
 
 
-def calculate_intersection_counts_under_backbone_nodes(mutation_list_under_backbone_nodes, M_current, I_attached, new_mut):
+def calculate_intersection_counts_under_backbone_nodes(
+    mutation_list_under_backbone_nodes,
+    M_current,
+    I_attached,
+    new_mut,
+    i_attached_positive=None,
+    i_attached_positive_values=None,
+    i_attached_positive_col_to_idx=None,
+    backbone_mutation_indices=None,
+    backbone_positive_masks=None,
+):
     """
     计算new_mut与每个backbone node下mutation list的共现数量
     
@@ -2866,40 +2872,50 @@ def calculate_intersection_counts_under_backbone_nodes(mutation_list_under_backb
         raise ValueError(f"突变 {new_mut} 不在 I_attached 数据框中")
     
     intersection_counts = {}
-    
+    if i_attached_positive is None:
+        i_attached_positive = I_attached.reindex(index=M_current.index).eq(1).fillna(False)
+    if i_attached_positive_values is None:
+        i_attached_positive_values = i_attached_positive.to_numpy(dtype=bool, copy=False)
+    if i_attached_positive_col_to_idx is None:
+        i_attached_positive_col_to_idx = {
+            col: idx for idx, col in enumerate(i_attached_positive.columns)
+        }
+
+    new_mut_idx = i_attached_positive_col_to_idx.get(new_mut)
+    if new_mut_idx is None:
+        raise ValueError(f"突变 {new_mut} 不在 I_attached 数据框中")
+
+    new_mut_positive_mask = i_attached_positive_values[:, new_mut_idx]
+
     for backbone_node, mutation_list in mutation_list_under_backbone_nodes.items():
-        # 1. 找到当前backbone node为1的细胞
-        backbone_cells = M_current[M_current[backbone_node] == 1].index
-        
-        # 2. 过滤出同时在I_attached中的细胞
-        common_cells = backbone_cells.intersection(I_attached.index)
-        
-        if len(common_cells) == 0:
+        if backbone_node not in M_current.columns:
             intersection_counts[backbone_node] = 0
             continue
-        
-        # 3. 获取这些细胞在new_mut上的状态
-        new_mut_status = I_attached.loc[common_cells, new_mut]
-        
-        # 4. 过滤出new_mut为1的细胞
-        new_mut_positive_cells = new_mut_status[new_mut_status == 1].index
-        
-        if len(new_mut_positive_cells) == 0:
+
+        if backbone_positive_masks is not None and backbone_node in backbone_positive_masks:
+            backbone_positive_mask = backbone_positive_masks[backbone_node]
+        else:
+            backbone_positive_mask = _coerce_bool_array(M_current[backbone_node], M_current.index)
+
+        selected_rows = backbone_positive_mask & new_mut_positive_mask
+        if not bool(selected_rows.any()):
             intersection_counts[backbone_node] = 0
             continue
-        
-        # 5. 对于每个mutation in mutation_list，计算与new_mut同时为1的数量
-        total_intersection = 0
-        
-        for mutation in mutation_list:
-            if mutation in I_attached.columns:
-                # 获取当前mutation在new_mut阳性细胞中的状态
-                mut_status = I_attached.loc[new_mut_positive_cells, mutation]
-                # 计算同时为1的数量（忽略NaN值）
-                intersection_count = (mut_status == 1).sum()
-                total_intersection += intersection_count
-        
-        intersection_counts[backbone_node] = total_intersection
+
+        if backbone_mutation_indices is not None and backbone_node in backbone_mutation_indices:
+            valid_indices = backbone_mutation_indices[backbone_node]
+        else:
+            valid_indices = [
+                i_attached_positive_col_to_idx[mutation]
+                for mutation in mutation_list
+                if mutation in i_attached_positive_col_to_idx
+            ]
+
+        if not valid_indices:
+            intersection_counts[backbone_node] = 0
+            continue
+
+        intersection_counts[backbone_node] = int(i_attached_positive_values[selected_rows][:, valid_indices].sum())
     
     return intersection_counts
 
@@ -2940,13 +2956,31 @@ def find_best_backbone_node(mutation_list_under_backbone_nodes, M_current, inter
     
     return best_node
 
-def find_best_backbone_for_new_mutation(mutation_list_under_backbone_nodes, M_current, I_attached, new_mut):
+def find_best_backbone_for_new_mutation(
+    mutation_list_under_backbone_nodes,
+    M_current,
+    I_attached,
+    new_mut,
+    i_attached_positive=None,
+    i_attached_positive_values=None,
+    i_attached_positive_col_to_idx=None,
+    backbone_mutation_indices=None,
+    backbone_positive_masks=None,
+):
     """
     完整函数：计算共现数量并找到最佳backbone node
     """
     # 第一步：计算共现数量
     intersection_counts = calculate_intersection_counts_under_backbone_nodes(
-        mutation_list_under_backbone_nodes, M_current, I_attached, new_mut
+        mutation_list_under_backbone_nodes,
+        M_current,
+        I_attached,
+        new_mut,
+        i_attached_positive=i_attached_positive,
+        i_attached_positive_values=i_attached_positive_values,
+        i_attached_positive_col_to_idx=i_attached_positive_col_to_idx,
+        backbone_mutation_indices=backbone_mutation_indices,
+        backbone_positive_masks=backbone_positive_masks,
     )
     
     # 第二步：找到最佳backbone node
@@ -2993,6 +3027,42 @@ def get_first_level_backbone_nodes(root: TreeNode) -> List[str]:
     for child in root.children:
         first_level_nodes.append(child.name)
     return first_level_nodes
+
+
+def _build_attach_tree_state(root: TreeNode) -> Dict[str, Any]:
+    """
+    为 Step6 挂树阶段构建一次性树状态缓存，减少单个 mutation 内的重复遍历。
+    """
+    traversed_nodes = list(root.traverse())
+    node_lookup = {}
+    tree_parent_dict = {}
+    node_to_mutations = {}
+
+    for node in traversed_nodes:
+        node_lookup[node.name] = node
+        node_to_mutations[node.name] = tuple(node.name.split("|")) if node.name != "ROOT" else ("ROOT",)
+        for child in node.children:
+            tree_parent_dict[child.name] = node.name
+
+    node_list_under_backbone_nodes = {}
+    mutation_list_under_backbone_nodes = {}
+    for child in root.children:
+        node_names = []
+        mutation_names = []
+        for node in child.traverse():
+            node_names.append(node.name)
+            mutation_names.extend(node_to_mutations[node.name])
+        node_list_under_backbone_nodes[child.name] = node_names
+        mutation_list_under_backbone_nodes[child.name] = mutation_names
+
+    return {
+        "tree_nodes": traversed_nodes,
+        "node_lookup": node_lookup,
+        "tree_parent_dict": tree_parent_dict,
+        "node_to_mutations": node_to_mutations,
+        "node_list_under_backbone_nodes": node_list_under_backbone_nodes,
+        "mutation_list_under_backbone_nodes": mutation_list_under_backbone_nodes,
+    }
 
 
 
@@ -3679,28 +3749,81 @@ def attach_mutations_to_current_tree(sorted_attached_mutations, T_current, M_cur
         root_mutations = []
     
     external_mutations = []
+    matrix_index = M_current.index
+    i_attached_positive = I_attached.reindex(index=matrix_index).eq(1).fillna(False)
+    i_attached_positive_values = i_attached_positive.to_numpy(dtype=bool, copy=False)
+    i_attached_positive_col_to_idx = {
+        col: idx for idx, col in enumerate(i_attached_positive.columns)
+    }
+    tree_state = None
+    tree_state_dirty = True
+
+    def ensure_tree_state():
+        nonlocal tree_state, tree_state_dirty
+        if tree_state is None or tree_state_dirty:
+            tree_state = _build_attach_tree_state(T_current)
+            backbone_positive_masks = {}
+            backbone_mutation_indices = {}
+            for backbone_node, mutation_list in tree_state["mutation_list_under_backbone_nodes"].items():
+                if backbone_node in M_current.columns:
+                    backbone_positive_masks[backbone_node] = _coerce_bool_array(
+                        M_current[backbone_node],
+                        matrix_index,
+                    )
+                backbone_mutation_indices[backbone_node] = [
+                    i_attached_positive_col_to_idx[mutation]
+                    for mutation in mutation_list
+                    if mutation in i_attached_positive_col_to_idx
+                ]
+            tree_state["backbone_positive_masks"] = backbone_positive_masks
+            tree_state["backbone_mutation_indices"] = backbone_mutation_indices
+            tree_state_dirty = False
+        return tree_state
     
     for new_mut in tqdm(sorted_attached_mutations, desc="Processing mutations", unit="mutation"):
         logger.info(f"Processing mutation: {new_mut}")
+        current_tree_state = ensure_tree_state()
         
         # 确定 new_mut 应该属于哪一个 backbone clone
-        mutation_list_under_backbone_nodes = get_mutation_clone_and_backbone_node_as_keys_by_first_level(T_current)
-        node_list_under_backbone_nodes = get_node_clone_and_backbone_node_as_keys_by_first_level(T_current)
-        # current_backbone_nodes = get_first_level_backbone_nodes(T_current)
-        # [i for i in list(mutation_list_under_backbone_nodes.keys()) if i not in current_backbone_nodes]
-        best_backbone, intersection_counts = find_best_backbone_for_new_mutation(mutation_list_under_backbone_nodes, M_current, I_attached, new_mut)
-        assigned_nodes = node_list_under_backbone_nodes[best_backbone]
+        best_backbone, intersection_counts = find_best_backbone_for_new_mutation(
+            current_tree_state["mutation_list_under_backbone_nodes"],
+            M_current,
+            I_attached,
+            new_mut,
+            i_attached_positive=i_attached_positive,
+            i_attached_positive_values=i_attached_positive_values,
+            i_attached_positive_col_to_idx=i_attached_positive_col_to_idx,
+            backbone_mutation_indices=current_tree_state["backbone_mutation_indices"],
+            backbone_positive_masks=current_tree_state["backbone_positive_masks"],
+        )
+        assigned_nodes = current_tree_state["node_list_under_backbone_nodes"][best_backbone]
         
         # 找到交集节点
-        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(T_current, I_attached, new_mut)
-        print(len(intersection_nodes))
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(
+            T_current,
+            I_attached,
+            new_mut,
+            matrix_positive=i_attached_positive,
+            matrix_positive_values=i_attached_positive_values,
+            matrix_positive_col_to_idx=i_attached_positive_col_to_idx,
+            tree_nodes=current_tree_state["tree_nodes"],
+            node_to_mutations=current_tree_state["node_to_mutations"],
+        )
         if len(intersection_nodes) == 0:
             external_mutations.append(new_mut)
             logger.info(f"Mutation {new_mut} added to external_mutations (no intersection found)")
             continue
         
         # 使用优化方法获取候选位置
-        potential_positions = find_intersection_positions_within_tree_directly(T_current, new_mut, I_attached, min_overlap=1)
+        potential_positions = find_intersection_positions_within_tree_directly(
+            T_current,
+            new_mut,
+            I_attached,
+            min_overlap=1,
+            intersection_nodes=intersection_nodes,
+            tree_parent_dict=current_tree_state["tree_parent_dict"],
+            node_lookup=current_tree_state["node_lookup"],
+        )
         parent_dict = build_parent_dict_from_candidates(potential_positions)
         selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] in assigned_nodes]
         
@@ -3726,10 +3849,9 @@ def attach_mutations_to_current_tree(sorted_attached_mutations, T_current, M_cur
         else:
             M_current[new_mut] = final_imputed_vec
             T_current = add_new_mutation_to_tree_independent(new_mut, T_current, final_position)
+        tree_state_dirty = True
         
-        # 打印当前树的结构
-        logger.info(f"Updated tree after mutation {new_mut}:")
-        print_tree(T_current)
+        _log_tree_snapshot(logger, f"Updated tree after mutation {new_mut}:", T_current)
         
         # 检查冲突
         if scp.ul.is_conflict_free_gusfield(M_current):
@@ -3809,7 +3931,13 @@ def process_rescue_mutations(sorted_rescue_mutations, T_current, M_current, I_at
             continue
         
         # 使用优化方法获取候选位置
-        potential_positions = find_intersection_positions_within_tree_directly(T_current, new_mut, I_attached, min_overlap=1)
+        potential_positions = find_intersection_positions_within_tree_directly(
+            T_current,
+            new_mut,
+            I_attached,
+            min_overlap=1,
+            intersection_nodes=intersection_nodes,
+        )
         parent_dict = build_parent_dict_from_candidates(potential_positions)
         
         # 检查是否找到候选位置（理论上这里应该有，但双重检查）
@@ -3863,9 +3991,7 @@ def process_rescue_mutations(sorted_rescue_mutations, T_current, M_current, I_at
             M_current[new_mut] = final_imputed_vec
             T_current = add_new_mutation_to_tree_independent(new_mut, T_current, final_position)
         
-        # 打印当前树的结构
-        logger.info(f"Updated tree after mutation {new_mut}:")
-        print_tree(T_current)
+        _log_tree_snapshot(logger, f"Updated tree after mutation {new_mut}:", T_current)
         
         # 检查冲突
         if scp.ul.is_conflict_free_gusfield(M_current):
@@ -3982,7 +4108,13 @@ def process_external_mutations_by_subtree_groups(
                     continue
                 
                 # 使用优化方法获取候选位置
-                potential_positions = find_intersection_positions_within_tree_directly(T_current, subtree_mut, I_attached, min_overlap=1)
+                potential_positions = find_intersection_positions_within_tree_directly(
+                    T_current,
+                    subtree_mut,
+                    I_attached,
+                    min_overlap=1,
+                    intersection_nodes=intersection_nodes,
+                )
                 parent_dict = build_parent_dict_from_candidates(potential_positions)
                 selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] in assigned_nodes]
                 
@@ -4011,9 +4143,7 @@ def process_external_mutations_by_subtree_groups(
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
             
-            # 打印当前树结构
-            logger.info(f"Tree after adding {subtree_mut}:")
-            print_tree(T_current)
+            _log_tree_snapshot(logger, f"Tree after adding {subtree_mut}:", T_current)
             
             # 检查冲突
             if not scp.ul.is_conflict_free_gusfield(M_current):
@@ -4056,7 +4186,13 @@ def process_external_mutations_by_subtree_groups(
                     continue
                 
                 # 使用优化方法获取候选位置
-                potential_positions = find_intersection_positions_within_tree_directly(T_current, subtree_mut, I_attached, min_overlap=1)
+                potential_positions = find_intersection_positions_within_tree_directly(
+                    T_current,
+                    subtree_mut,
+                    I_attached,
+                    min_overlap=1,
+                    intersection_nodes=intersection_nodes,
+                )
                 parent_dict = build_parent_dict_from_candidates(potential_positions)
                 selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] in assigned_nodes]
                 
@@ -4085,9 +4221,7 @@ def process_external_mutations_by_subtree_groups(
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 
-                # 打印当前树结构
-                logger.info(f"Updated tree after re-attaching mutation {subtree_mut}:")
-                print_tree(T_current)
+                _log_tree_snapshot(logger, f"Updated tree after re-attaching mutation {subtree_mut}:", T_current)
                 
                 # 检查冲突
                 if not scp.ul.is_conflict_free_gusfield(M_current):
@@ -4120,8 +4254,7 @@ def process_external_mutations_by_subtree_groups(
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
         
-        logger.info(f"Tree after adding singleton {subtree_mut}:")
-        print_tree(T_current)
+        _log_tree_snapshot(logger, f"Tree after adding singleton {subtree_mut}:", T_current)
         
         if not scp.ul.is_conflict_free_gusfield(M_current):
             logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")

--- a/src/mutation_integrator.py
+++ b/src/mutation_integrator.py
@@ -4432,6 +4432,37 @@ def process_external_mutations_by_subtree_groups(
         root_mutations = []
     
     remained_mutations = []
+    matrix_index = M_current.index
+    i_attached_positive = I_attached.reindex(index=matrix_index).eq(1).fillna(False)
+    i_attached_positive_values = i_attached_positive.to_numpy(dtype=bool, copy=False)
+    i_attached_positive_col_to_idx = {
+        col: idx for idx, col in enumerate(i_attached_positive.columns)
+    }
+
+    tree_state = None
+    tree_state_dirty = True
+
+    def ensure_tree_state():
+        nonlocal tree_state, tree_state_dirty
+        if tree_state is None or tree_state_dirty:
+            tree_state = _build_attach_tree_state(T_current)
+            backbone_positive_masks = {}
+            backbone_mutation_indices = {}
+            for backbone_node, mutation_list in tree_state["mutation_list_under_backbone_nodes"].items():
+                if backbone_node in M_current.columns:
+                    backbone_positive_masks[backbone_node] = _coerce_bool_array(
+                        M_current[backbone_node],
+                        matrix_index,
+                    )
+                backbone_mutation_indices[backbone_node] = [
+                    i_attached_positive_col_to_idx[mutation]
+                    for mutation in mutation_list
+                    if mutation in i_attached_positive_col_to_idx
+                ]
+            tree_state["backbone_positive_masks"] = backbone_positive_masks
+            tree_state["backbone_mutation_indices"] = backbone_mutation_indices
+            tree_state_dirty = False
+        return tree_state
     
     # 分离子树组和单元素组
     multi_mut_subtree_groups = [g for g in subtree_groups if len(g) > 1]
@@ -4461,19 +4492,35 @@ def process_external_mutations_by_subtree_groups(
                 T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
                 touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []
+                tree_state_dirty = True
             
             else:
+                current_tree_state = ensure_tree_state()
                 
-                # 确定 subtree_mut 应该属于哪一个 backbone clone
-                mutation_list_under_backbone_nodes = get_mutation_clone_and_backbone_node_as_keys_by_first_level(T_current)
-                node_list_under_backbone_nodes = get_node_clone_and_backbone_node_as_keys_by_first_level(T_current)
-                # current_backbone_nodes = get_first_level_backbone_nodes(T_current)
-                # [i for i in list(mutation_list_under_backbone_nodes.keys()) if i not in current_backbone_nodes]
-                best_backbone, intersection_counts = find_best_backbone_for_new_mutation(mutation_list_under_backbone_nodes, M_current, I_attached, subtree_mut)
-                assigned_nodes = node_list_under_backbone_nodes[best_backbone]
+                best_backbone, intersection_counts = find_best_backbone_for_new_mutation(
+                    current_tree_state["mutation_list_under_backbone_nodes"],
+                    M_current,
+                    I_attached,
+                    subtree_mut,
+                    i_attached_positive=i_attached_positive,
+                    i_attached_positive_values=i_attached_positive_values,
+                    i_attached_positive_col_to_idx=i_attached_positive_col_to_idx,
+                    backbone_mutation_indices=current_tree_state["backbone_mutation_indices"],
+                    backbone_positive_masks=current_tree_state["backbone_positive_masks"],
+                )
+                assigned_nodes = current_tree_state["node_list_under_backbone_nodes"][best_backbone]
                 
                 # 找到交集节点
-                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(T_current, I_attached, subtree_mut)
+                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(
+                    T_current,
+                    I_attached,
+                    subtree_mut,
+                    matrix_positive=i_attached_positive,
+                    matrix_positive_values=i_attached_positive_values,
+                    matrix_positive_col_to_idx=i_attached_positive_col_to_idx,
+                    tree_nodes=current_tree_state["tree_nodes"],
+                    node_to_mutations=current_tree_state["node_to_mutations"],
+                )
                 if len(intersection_nodes) == 0:
                     reattached_mutations.append(subtree_mut)
                     logger.info(f"Mutation {subtree_mut} added to reattached_mutations (no intersection found)")
@@ -4486,6 +4533,8 @@ def process_external_mutations_by_subtree_groups(
                     I_attached,
                     min_overlap=1,
                     intersection_nodes=intersection_nodes,
+                    tree_parent_dict=current_tree_state["tree_parent_dict"],
+                    node_lookup=current_tree_state["node_lookup"],
                 )
                 parent_dict = build_parent_dict_from_candidates(potential_positions)
                 selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] in assigned_nodes]
@@ -4521,6 +4570,7 @@ def process_external_mutations_by_subtree_groups(
                 else:
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
+                tree_state_dirty = True
                 touched_columns = _resolve_touched_columns_for_conflict_check(
                     final_position,
                     parent_dict,
@@ -4542,6 +4592,7 @@ def process_external_mutations_by_subtree_groups(
                 # 回滚操作：从矩阵中移除这个突变
                 T_current = copy.deepcopy(T_rollback)
                 M_current = M_rollback.copy()
+                tree_state_dirty = True
                 
                 # 把这个突变放到external_mutations
                 reattached_mutations.append(subtree_mut)
@@ -4556,17 +4607,32 @@ def process_external_mutations_by_subtree_groups(
             sorted_reattached_mutations = [i for i in I_attached.columns if i in reattached_mutations]
             for subtree_mut in tqdm(sorted_reattached_mutations, desc="Processing re-attached mutations"):
                 logger.info(f"Processing re-attached mutation: {subtree_mut}")
+                current_tree_state = ensure_tree_state()
                 
-                # 确定 subtree_mut 应该属于哪一个 backbone clone
-                mutation_list_under_backbone_nodes = get_mutation_clone_and_backbone_node_as_keys_by_first_level(T_current)
-                node_list_under_backbone_nodes = get_node_clone_and_backbone_node_as_keys_by_first_level(T_current)
-                # current_backbone_nodes = get_first_level_backbone_nodes(T_current)
-                # [i for i in list(mutation_list_under_backbone_nodes.keys()) if i not in current_backbone_nodes]
-                best_backbone, intersection_counts = find_best_backbone_for_new_mutation(mutation_list_under_backbone_nodes, M_current, I_attached, subtree_mut)
-                assigned_nodes = node_list_under_backbone_nodes[best_backbone]
+                best_backbone, intersection_counts = find_best_backbone_for_new_mutation(
+                    current_tree_state["mutation_list_under_backbone_nodes"],
+                    M_current,
+                    I_attached,
+                    subtree_mut,
+                    i_attached_positive=i_attached_positive,
+                    i_attached_positive_values=i_attached_positive_values,
+                    i_attached_positive_col_to_idx=i_attached_positive_col_to_idx,
+                    backbone_mutation_indices=current_tree_state["backbone_mutation_indices"],
+                    backbone_positive_masks=current_tree_state["backbone_positive_masks"],
+                )
+                assigned_nodes = current_tree_state["node_list_under_backbone_nodes"][best_backbone]
                 
                 # 找到交集节点
-                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(T_current, I_attached, subtree_mut)
+                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix(
+                    T_current,
+                    I_attached,
+                    subtree_mut,
+                    matrix_positive=i_attached_positive,
+                    matrix_positive_values=i_attached_positive_values,
+                    matrix_positive_col_to_idx=i_attached_positive_col_to_idx,
+                    tree_nodes=current_tree_state["tree_nodes"],
+                    node_to_mutations=current_tree_state["node_to_mutations"],
+                )
                 if len(intersection_nodes) == 0:
                     second_reattached_mutations.append(subtree_mut)
                     logger.info(f"Mutation {subtree_mut} added to second_reattached_mutations (no intersection found)")
@@ -4579,6 +4645,8 @@ def process_external_mutations_by_subtree_groups(
                     I_attached,
                     min_overlap=1,
                     intersection_nodes=intersection_nodes,
+                    tree_parent_dict=current_tree_state["tree_parent_dict"],
+                    node_lookup=current_tree_state["node_lookup"],
                 )
                 parent_dict = build_parent_dict_from_candidates(potential_positions)
                 selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] in assigned_nodes]
@@ -4614,6 +4682,7 @@ def process_external_mutations_by_subtree_groups(
                 else:
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
+                tree_state_dirty = True
                 touched_columns = _resolve_touched_columns_for_conflict_check(
                     final_position,
                     parent_dict,
@@ -4635,6 +4704,7 @@ def process_external_mutations_by_subtree_groups(
                     # 回滚操作：从矩阵中移除这个突变
                     T_current = copy.deepcopy(T_rollback)
                     M_current = M_rollback.copy()
+                    tree_state_dirty = True
                     
                     # 把这个突变放到external_mutations
                     second_reattached_mutations.append(subtree_mut)
@@ -4657,6 +4727,7 @@ def process_external_mutations_by_subtree_groups(
         M_rollback = M_current.copy()
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
+        tree_state_dirty = True
         touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []
         
         _log_tree_snapshot(logger, f"Tree after adding singleton {subtree_mut}:", T_current)
@@ -4672,6 +4743,7 @@ def process_external_mutations_by_subtree_groups(
             # 回滚操作：从矩阵中移除这个突变
             T_current = copy.deepcopy(T_rollback)
             M_current = M_rollback.copy()
+            tree_state_dirty = True
             
             # 把这个突变放到external_mutations
             remained_mutations.append(subtree_mut)

--- a/src/mutation_integrator.py
+++ b/src/mutation_integrator.py
@@ -1527,6 +1527,33 @@ def select_best_clone(detailed_scores):
 # 计算 bayesian 罚分
 # -------------------------
 
+def _build_step6_lineage_fill_update(final_position, final_imputed_vec, full_mutnode_chain):
+    if final_position is None or final_imputed_vec is None:
+        return {"mutation_chain": (), "cells": ()}
+
+    cells = tuple(final_imputed_vec.index[final_imputed_vec == 1].tolist())
+    return {
+        "mutation_chain": tuple(full_mutnode_chain),
+        "cells": cells,
+    }
+
+
+def _apply_step6_lineage_fill_to_matrix(M_current, lineage_fill_update):
+    mutation_chain = lineage_fill_update.get("mutation_chain", ())
+    cells = lineage_fill_update.get("cells", ())
+
+    if not mutation_chain or not cells:
+        return M_current
+
+    cells_list = list(cells)
+    chain_columns = [mutation for mutation in mutation_chain if mutation in M_current.columns]
+    if not chain_columns:
+        return M_current
+
+    chain_block = M_current.loc[cells_list, chain_columns]
+    M_current.loc[cells_list, chain_columns] = chain_block.mask(chain_block == 0, 1)
+    return M_current
+
 def compute_bayesian_penalty_for_positions_consider_ROOT(
     new_mut, selected_positions, T_current, M_current, I_selected, P_selected, parent_dict, intersection_nodes, 
     ω_NA=0.001, fnfp_ratio=0.1, φ=1
@@ -1534,11 +1561,12 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
     import pandas as pd
     import numpy as np
     results = []
+    empty_lineage_fill_update = {"mutation_chain": (), "cells": ()}
     
     # 如果没有候选位置，直接返回 None
     if len(selected_positions) == 0:
         logger.warning(f"No selected positions for mutation {new_mut}")
-        return None, None, pd.DataFrame(), M_current
+        return None, None, pd.DataFrame(), empty_lineage_fill_update
     
     matrix_index = M_current.index
     matrix_columns = M_current.columns
@@ -1887,24 +1915,24 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         # -------------------------
         if len(results) == 0:
             logger.warning(f"No valid results for mutation {new_mut}")
-            return None, None, pd.DataFrame(), M_current
+            return None, None, pd.DataFrame(), empty_lineage_fill_update
         
         df_penalty = pd.DataFrame(results)
         
         # 检查 DataFrame 是否为空
         if df_penalty.empty:
             logger.warning(f"Empty penalty DataFrame for mutation {new_mut}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 检查 total_penalty 列是否存在
         if 'total_penalty' not in df_penalty.columns:
             logger.warning(f"total_penalty column missing for mutation {new_mut}. Columns: {df_penalty.columns.tolist()}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 检查 total_penalty 列是否有有效值
         if df_penalty['total_penalty'].isna().all():
             logger.warning(f"All total_penalty values are NaN for mutation {new_mut}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 查找最小 penalty 并检查 imputed_vec 是否全为 0
         valid_results = []
@@ -1916,7 +1944,7 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         
         if not valid_results:
             logger.warning(f"No valid results (with non-zero imputed_vec) for mutation {new_mut}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 选择最小 penalty 的有效位置
         df_valid_penalty = pd.DataFrame(valid_results)
@@ -1926,30 +1954,17 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         final_position = min_row['position']
         final_imputed_vec = min_row['imputed_vec'].copy()
         
-        # -------------------------
-        # 修正：简化的M_current更新逻辑
-        # -------------------------
-        anchor = final_position['anchor']
+        lineage_fill_update = _build_step6_lineage_fill_update(
+            final_position,
+            final_imputed_vec,
+            min_row['full_mutnode_chain'],
+        )
         
-        # 获取从锚点到ROOT的完整突变链
-        full_mutnode_chain = get_full_mutnode_chain_with_anchor(anchor, parent_dict)
-        
-        # 找出所有在final_imputed_vec中为1的细胞
-        cells_with_final_one = final_imputed_vec[final_imputed_vec == 1].index.tolist()
-        
-        if len(cells_with_final_one) > 0:
-            # 对于每个在final_imputed_vec中为1的细胞，确保其父节点链也为1
-            for cell in cells_with_final_one:
-                for mutation in full_mutnode_chain:
-                    # 只有当该突变当前为0时才填充为1
-                    if M_current.loc[cell, mutation] == 0:
-                        M_current.loc[cell, mutation] = 1
-        
-        return final_position, final_imputed_vec.astype(int), df_penalty, M_current
+        return final_position, final_imputed_vec.astype(int), df_penalty, lineage_fill_update
     
     except Exception as e:
         logger.warning(f"Error selecting minimum penalty for mutation {new_mut}: {e}")
-        return None, None, df_penalty, M_current
+        return None, None, df_penalty, empty_lineage_fill_update
 
 
 # 保留原有的辅助函数，因为它们已经在第一个函数中定义过了
@@ -4151,10 +4166,15 @@ def attach_mutations_to_current_tree(sorted_attached_mutations, T_current, M_cur
             selected_positions = [p for i,p in enumerate(potential_positions) if p['anchor'] != 'ROOT']
         
         # 计算贝叶斯罚分并更新 M_current
-        final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_consider_ROOT(
+        final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_consider_ROOT(
             new_mut, selected_positions, T_current, M_current, I_attached, P_attached, parent_dict, intersection_nodes, 
             ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
         )
+        if final_position is None or final_imputed_vec is None:
+            external_mutations.append(new_mut)
+            logger.info(f"Mutation {new_mut} added to external_mutations (no valid scoring result)")
+            continue
+        M_current = _apply_step6_lineage_fill_to_matrix(M_current, lineage_fill_update)
         logger.info(f"The new_mut should be placed on position: {final_position['placement_type']}.")
         
         # 更新 M_current
@@ -4306,10 +4326,15 @@ def process_rescue_mutations(sorted_rescue_mutations, T_current, M_current, I_at
         ]
         
         # 计算贝叶斯罚分并更新 M_current
-        final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_consider_ROOT(
+        final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_consider_ROOT(
             new_mut, selected_positions, T_current, M_current, I_attached, P_attached, parent_dict, intersection_nodes, 
             ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
         )
+        if final_position is None or final_imputed_vec is None:
+            external_mutations.append(new_mut)
+            logger.info(f"Mutation {new_mut} added to external_mutations (no valid scoring result)")
+            continue
+        M_current = _apply_step6_lineage_fill_to_matrix(M_current, lineage_fill_update)
         logger.info(f"The new_mut should be placed on position: {final_position['placement_type']}.")
         
         # 更新 M_current
@@ -4426,14 +4451,13 @@ def process_external_mutations_by_subtree_groups(
         reattached_mutations = []
         
         for idx, subtree_mut in enumerate(tqdm(sorted_group, desc="Processing mutations in group")):
-            T_rollback = copy.deepcopy(T_current)
-            M_rollback = M_current.copy()
-            
             logger.info(f"Processing mutation {idx+1}/{len(sorted_group)}: {subtree_mut}")
             
             if idx == 0:
                 # 第一个 mutation 直接挂到 ROOT
                 final_position = generate_new_leaf_on_root(T_current, subtree_mut)
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
                 T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
                 touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []
@@ -4473,10 +4497,17 @@ def process_external_mutations_by_subtree_groups(
                     continue
                 
                 # 计算贝叶斯罚分并更新 M_current
-                final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_consider_ROOT(
+                final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_consider_ROOT(
                     subtree_mut, selected_positions, T_current, M_current, I_attached, P_attached, parent_dict, 
                     intersection_nodes, ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
                 )
+                if final_position is None or final_imputed_vec is None:
+                    reattached_mutations.append(subtree_mut)
+                    logger.info(f"Mutation {subtree_mut} added to reattached_mutations (no valid scoring result)")
+                    continue
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
+                M_current = _apply_step6_lineage_fill_to_matrix(M_current, lineage_fill_update)
                 logger.info(f"Mutation {subtree_mut} should be placed on position: {final_position['placement_type']}")
                 
                 # 更新 M_current
@@ -4524,9 +4555,6 @@ def process_external_mutations_by_subtree_groups(
             
             sorted_reattached_mutations = [i for i in I_attached.columns if i in reattached_mutations]
             for subtree_mut in tqdm(sorted_reattached_mutations, desc="Processing re-attached mutations"):
-                T_rollback = copy.deepcopy(T_current)
-                M_rollback = M_current.copy()
-                
                 logger.info(f"Processing re-attached mutation: {subtree_mut}")
                 
                 # 确定 subtree_mut 应该属于哪一个 backbone clone
@@ -4562,10 +4590,17 @@ def process_external_mutations_by_subtree_groups(
                     continue
                 
                 # 计算贝叶斯罚分并更新 M_current
-                final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_consider_ROOT(
+                final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_consider_ROOT(
                     subtree_mut, selected_positions, T_current, M_current, I_attached, P_attached, parent_dict, intersection_nodes, 
                     ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
                 )
+                if final_position is None or final_imputed_vec is None:
+                    second_reattached_mutations.append(subtree_mut)
+                    logger.info(f"Mutation {subtree_mut} added to second_reattached_mutations (no valid scoring result)")
+                    continue
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
+                M_current = _apply_step6_lineage_fill_to_matrix(M_current, lineage_fill_update)
                 logger.info(f"The subtree_mut should be placed on position: {final_position['placement_type']}.")
                 
                 # 更新 M_current
@@ -4614,13 +4649,12 @@ def process_external_mutations_by_subtree_groups(
     ##### 处理长度 =1 的单元素组
     logger.info(f"Processing {len(singleton_subtree_groups)} singleton groups")
     for group in tqdm(singleton_subtree_groups, desc="Processing singleton subtrees"):
-        T_rollback = copy.deepcopy(T_current)
-        M_rollback = M_current.copy()            
-        
         subtree_mut = group[0]
         logger.info(f"Attaching singleton mutation directly to ROOT: {subtree_mut}")
         
         final_position = generate_new_leaf_on_root(T_current, subtree_mut)
+        T_rollback = copy.deepcopy(T_current)
+        M_rollback = M_current.copy()
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
         touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []

--- a/src/mutation_integrator.py
+++ b/src/mutation_integrator.py
@@ -2280,73 +2280,66 @@ def calculate_fp_fn_ratios_across_tree(M_checkpoint, I_attached):
     DataFrame: 包含每个突变的fp_ratio和fn_ratio
     dict: 包含每个突变对应的fp>0的其他突变列表
     """
-    mutations = M_checkpoint.columns
-    results = []
-    fp_mutations_dict = {}  # 存储每个突变对应的fp>0的其他突变
-    
-    for mut in mutations:
-        # 1. 计算fp_ratio
-        mutant_cells = M_checkpoint[M_checkpoint[mut] == 1].index
-        fp_ratios = []
-        fp_positive_muts = []  # 存储当前突变fp>0的其他突变
-        
-        for other_mut in mutations:
-            if other_mut == mut:
-                continue
-                
-            # 在当前突变的clone中计算其他突变的FP
-            other_original = I_attached.loc[mutant_cells, other_mut]
-            other_imputed = M_checkpoint.loc[mutant_cells, other_mut]
-            # FP: 原始为1但imputed为0
-            fp_count = ((other_original == 1) & (other_imputed == 0)).sum()
-            
-            # 在所有 cells 中计算其他突变的FP
-            total_other_original = I_attached.loc[:, other_mut]
-            total_other_imputed = M_checkpoint.loc[:, other_mut]
-            total_fp_count = ((total_other_original == 1) & (total_other_imputed == 0)).sum()
-            
-            if total_fp_count > 0:
-                fp_ratio = fp_count / total_fp_count
-                fp_ratios.append(fp_ratio)
-                
-                # 如果fp_ratio > 0，记录这个other_mut
-                if fp_ratio > 0:
-                    fp_positive_muts.append(other_mut)
-            else:
-                fp_ratios.append(0)
-        
-        # 将当前突变的fp>0的其他突变存入字典
-        fp_mutations_dict[mut] = fp_positive_muts
-        
-        avg_fp_ratio = np.mean(fp_ratios) if fp_ratios else 0
-        
-        # 2. 计算fn_ratio (保持不变)
-        mut_original = I_attached.loc[mutant_cells, mut]
-        mut_imputed = M_checkpoint.loc[mutant_cells, mut]
-        
-        # 该突变在原始数据中为0的细胞
-        zero_cells = mut_original[mut_original == 0].index
-        
-        # 计算与其他突变有intersection的细胞数
-        I_attached_sub_mut = I_attached.loc[mutant_cells, :]
-        row_counts = I_attached_sub_mut.eq(1).sum(axis=1)
-        intersect_cells = mut_original[(mut_original == 1) & (row_counts > 1)]
-        
-        total_zeros = len(zero_cells)
-        total_intersect = len(intersect_cells)
-        
-        if (total_zeros + total_intersect) > 0:
-            fn_ratio = total_zeros / (total_zeros + total_intersect)
-        else:
-            fn_ratio = 0
-        
-        results.append({
-            'identifier': mut,
-            'fp_ratio': avg_fp_ratio,
-            'fn_ratio': fn_ratio
-        })
-    
-    return pd.DataFrame(results), fp_mutations_dict
+    mutations = list(M_checkpoint.columns)
+    if not mutations:
+        return pd.DataFrame(columns=["identifier", "fp_ratio", "fn_ratio"]), {}
+
+    i_aligned = I_attached.reindex(index=M_checkpoint.index)
+    i_original = i_aligned.reindex(columns=mutations)
+
+    m_values = M_checkpoint.to_numpy(copy=False)
+    m_is_one = np.asarray(m_values == 1, dtype=bool)
+    m_is_zero = np.asarray(m_values == 0, dtype=bool)
+    i_is_one = np.asarray(i_original.eq(1).to_numpy(copy=False), dtype=bool)
+    fp_events = i_is_one & m_is_zero
+
+    # fp_count_matrix[i, j] = mutation i 的 clone 中，mutation j 的 FP 个数
+    fp_count_matrix = m_is_one.T.astype(np.int32) @ fp_events.astype(np.int32)
+    total_fp_counts = fp_events.sum(axis=0, dtype=np.int32)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        fp_ratio_matrix = np.divide(
+            fp_count_matrix,
+            total_fp_counts[np.newaxis, :],
+            out=np.zeros_like(fp_count_matrix, dtype=np.float64),
+            where=total_fp_counts[np.newaxis, :] > 0,
+        )
+
+    if len(mutations) > 1:
+        fp_ratio_sum = fp_ratio_matrix.sum(axis=1) - np.diag(fp_ratio_matrix)
+        avg_fp_ratios = fp_ratio_sum / (len(mutations) - 1)
+    else:
+        avg_fp_ratios = np.zeros(1, dtype=np.float64)
+
+    row_one_counts = np.asarray(i_aligned.eq(1).sum(axis=1).to_numpy(copy=False), dtype=np.int32)
+    orig_mut_is_zero = np.asarray(i_original.eq(0).to_numpy(copy=False), dtype=bool)
+    total_zeros = (m_is_one & orig_mut_is_zero).sum(axis=0, dtype=np.int32)
+    total_intersect = (m_is_one & i_is_one & (row_one_counts[:, None] > 1)).sum(axis=0, dtype=np.int32)
+    fn_denominator = total_zeros + total_intersect
+    with np.errstate(divide="ignore", invalid="ignore"):
+        fn_ratios = np.divide(
+            total_zeros,
+            fn_denominator,
+            out=np.zeros_like(total_zeros, dtype=np.float64),
+            where=fn_denominator > 0,
+        )
+
+    fp_mutations_dict = {}
+    for idx, mut in enumerate(mutations):
+        fp_mutations_dict[mut] = [
+            other_mut
+            for j, other_mut in enumerate(mutations)
+            if j != idx and fp_ratio_matrix[idx, j] > 0
+        ]
+
+    results = pd.DataFrame(
+        {
+            "identifier": mutations,
+            "fp_ratio": avg_fp_ratios,
+            "fn_ratio": fn_ratios,
+        }
+    )
+    return results, fp_mutations_dict
 
 # # 使用
 # ratios_df, fp_mutations_dict = calculate_fp_fn_ratios_across_tree(M_checkpoint, I_attached)

--- a/src/mutation_integrator.py
+++ b/src/mutation_integrator.py
@@ -196,11 +196,166 @@ def _coerce_bool_array(series, index):
     return series.reindex(index, fill_value=0).fillna(0).to_numpy(dtype=bool, copy=False)
 
 
+def _coerce_float_array(series, index):
+    return pd.to_numeric(series.reindex(index), errors="coerce").to_numpy(
+        dtype=np.float64,
+        na_value=np.nan,
+    )
+
+
 def _log_tree_snapshot(active_logger, label, tree):
     if not _VERBOSE_TREE_UPDATES:
         return
     active_logger.info(label)
     print_tree(tree)
+
+
+def _sanitize_matrix_for_conflict_check(matrix, active_logger, context_label, sample_limit=5):
+    values = matrix.to_numpy(copy=False)
+    try:
+        finite_mask = np.isfinite(values)
+        numeric_values = values.astype(np.float64, copy=False)
+    except TypeError:
+        numeric_values = matrix.apply(pd.to_numeric, errors="coerce").to_numpy(
+            dtype=np.float64,
+            copy=False,
+            na_value=np.nan,
+        )
+        finite_mask = np.isfinite(numeric_values)
+
+    if bool(finite_mask.all()):
+        return matrix
+
+    invalid_positions = np.argwhere(~finite_mask)
+    samples = [
+        f"{matrix.index[row]}::{matrix.columns[col]}={numeric_values[row, col]}"
+        for row, col in invalid_positions[:sample_limit]
+    ]
+    active_logger.warning(
+        "%s sanitizing matrix before conflict check: non_finite=%d sample=%s",
+        context_label,
+        int((~finite_mask).sum()),
+        samples,
+    )
+
+    sanitized_values = np.nan_to_num(
+        numeric_values,
+        nan=0.0,
+        posinf=1.0,
+        neginf=0.0,
+        copy=True,
+    )
+    binary_values = (sanitized_values > 0).astype(np.int8, copy=False)
+    return pd.DataFrame(binary_values, index=matrix.index, columns=matrix.columns)
+
+
+def _is_conflict_free_gusfield_safe(matrix, active_logger=None, context_label="ConflictCheck"):
+    if active_logger is None:
+        active_logger = logger
+    try:
+        return scp.ul.is_conflict_free_gusfield(matrix)
+    except (pd.errors.IntCastingNaNError, ValueError, TypeError) as exc:
+        active_logger.warning(
+            "%s conflict check retry after non-binary/non-finite matrix error: %s",
+            context_label,
+            exc,
+        )
+        matrix_for_check = _sanitize_matrix_for_conflict_check(matrix, active_logger, context_label)
+        return scp.ul.is_conflict_free_gusfield(matrix_for_check)
+
+
+def _resolve_touched_columns_for_conflict_check(final_position, parent_dict, matrix_columns, new_mut):
+    """Return the matrix columns whose updates could introduce new conflicts."""
+    placement_type = final_position.get("placement_type")
+    anchor = final_position.get("anchor")
+    matrix_column_set = set(matrix_columns)
+    touched_columns = []
+    seen = set()
+
+    if anchor is not None:
+        for node in get_full_mutnode_chain_with_anchor(anchor, parent_dict):
+            if node == "ROOT":
+                continue
+            resolved_node = node
+            if placement_type == "on_node" and node == anchor and anchor != "ROOT":
+                resolved_node = f"{anchor}|{new_mut}"
+            if resolved_node in matrix_column_set and resolved_node not in seen:
+                touched_columns.append(resolved_node)
+                seen.add(resolved_node)
+
+    if placement_type != "on_node" and new_mut in matrix_column_set and new_mut not in seen:
+        touched_columns.append(new_mut)
+
+    return touched_columns
+
+
+def _is_conflict_free_local_update(matrix, touched_columns, active_logger=None, context_label="LocalConflictCheck", sample_limit=5):
+    """
+    Exact local conflict check using the four-gamete criterion.
+
+    Only pairs involving touched columns can introduce a new conflict because
+    untouched-vs-untouched pairs are unchanged by the latest placement step.
+    """
+    if active_logger is None:
+        active_logger = logger
+
+    if not touched_columns:
+        return True
+
+    missing = [col for col in touched_columns if col not in matrix.columns]
+    if missing:
+        active_logger.warning(
+            "%s touched columns missing from matrix; falling back to full check. sample=%s",
+            context_label,
+            missing[:sample_limit],
+        )
+        return _is_conflict_free_gusfield_safe(matrix, active_logger, context_label)
+
+    values = matrix.to_numpy(copy=False)
+    if np.issubdtype(values.dtype, np.bool_):
+        bool_values = values
+    elif np.issubdtype(values.dtype, np.integer):
+        bool_values = values > 0
+    elif np.issubdtype(values.dtype, np.floating):
+        bool_values = np.nan_to_num(values, nan=0.0, posinf=1.0, neginf=0.0, copy=True) > 0
+    else:
+        numeric_values = matrix.apply(pd.to_numeric, errors="coerce").to_numpy(
+            dtype=np.float64,
+            copy=False,
+            na_value=np.nan,
+        )
+        bool_values = np.nan_to_num(numeric_values, nan=0.0, posinf=1.0, neginf=0.0, copy=True) > 0
+
+    all_columns = matrix.columns
+    touched_indices = all_columns.get_indexer(touched_columns)
+    if np.any(touched_indices < 0):
+        unresolved = [touched_columns[i] for i, idx in enumerate(touched_indices) if idx < 0]
+        active_logger.warning(
+            "%s unresolved touched indices; falling back to full check. sample=%s",
+            context_label,
+            unresolved[:sample_limit],
+        )
+        return _is_conflict_free_gusfield_safe(matrix, active_logger, context_label)
+
+    for touched_name, touched_idx in zip(touched_columns, touched_indices):
+        col = bool_values[:, touched_idx][:, None]
+        has10 = np.any(col & ~bool_values, axis=0)
+        has01 = np.any(~col & bool_values, axis=0)
+        has11 = np.any(col & bool_values, axis=0)
+        conflict_mask = has10 & has01 & has11
+        conflict_mask[touched_idx] = False
+        if bool(conflict_mask.any()):
+            conflict_indices = np.flatnonzero(conflict_mask)[:sample_limit]
+            conflict_columns = [all_columns[i] for i in conflict_indices]
+            active_logger.warning(
+                "%s detected local conflict: touched=%s conflicts=%s",
+                context_label,
+                touched_name,
+                conflict_columns,
+            )
+            return False
+
+    return True
 
 
 
@@ -1376,21 +1531,55 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
     new_mut, selected_positions, T_current, M_current, I_selected, P_selected, parent_dict, intersection_nodes, 
     ω_NA=0.001, fnfp_ratio=0.1, φ=1
 ):
-    import copy
     import pandas as pd
     import numpy as np
     results = []
-    matrix_index = M_current.index
-    lineage_parent_cache = {}
-    conflict_mask_cache = {}
     
     # 如果没有候选位置，直接返回 None
     if len(selected_positions) == 0:
         logger.warning(f"No selected positions for mutation {new_mut}")
         return None, None, pd.DataFrame(), M_current
     
-    new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
-    new_mut_mask = as_binary_mask(new_mut_bin_vector, matrix_index)
+    matrix_index = M_current.index
+    matrix_columns = M_current.columns
+    matrix_column_count = len(matrix_columns)
+    log_matrix_column_count = np.log(matrix_column_count)
+    new_mut_input_vector = I_selected[new_mut].replace({pd.NA: np.nan})
+    new_mut_mask = as_binary_mask(new_mut_input_vector.fillna(0).astype(int), matrix_index)
+    new_mut_mask_array = new_mut_mask.to_numpy(dtype=bool, copy=False)
+    mut_cells_new_mut = set(matrix_index[new_mut_mask_array])
+    non_root_columns_set = {col for col in matrix_columns if col != 'ROOT'}
+    m_current_bool_cache = {}
+    m_current_array_cache = {}
+    lineage_parent_cache = {}
+    conflict_nodes_cache = {}
+    conflict_vector_cache = {}
+    full_chain_cache = {}
+    node_mutations_cache = {}
+    cell_set_cache = {}
+    children_cache = {}
+    i_selected_cache = {new_mut: new_mut_input_vector}
+    i_selected_array_cache = {
+        new_mut: pd.to_numeric(new_mut_input_vector.reindex(matrix_index), errors="coerce").to_numpy(
+            dtype=np.float64,
+            na_value=np.nan,
+        )
+    }
+    p_selected_cache = {new_mut: P_selected[new_mut]}
+
+    def get_m_current_bool(column_name):
+        cached = m_current_bool_cache.get(column_name)
+        if cached is None:
+            cached = _coerce_bool_array(M_current[column_name], matrix_index)
+            m_current_bool_cache[column_name] = cached
+        return cached
+
+    def get_m_current_array(column_name):
+        cached = m_current_array_cache.get(column_name)
+        if cached is None:
+            cached = _coerce_float_array(M_current[column_name], matrix_index)
+            m_current_array_cache[column_name] = cached
+        return cached
 
     def get_lineage_parent_dict(anchor_name):
         cached = lineage_parent_cache.get(anchor_name)
@@ -1403,7 +1592,7 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         exclude_nodes = tuple(exclude_nodes or ())
         sibling_key = tuple(sorted(sibling_nodes))
         cache_key = (anchor_name, sibling_key, exclude_nodes)
-        cached = conflict_mask_cache.get(cache_key)
+        cached = conflict_nodes_cache.get(cache_key)
         if cached is None:
             lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage(
                 anchor_name,
@@ -1411,16 +1600,76 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
                 M_current.columns,
                 exclude_nodes=list(exclude_nodes),
             )
-            all_conflict_nodes = tuple(set(sibling_nodes + lineage_conflict_nodes))
-            vec_conflicts = pd.Series(False, index=matrix_index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= as_binary_mask(M_current[conflict], matrix_index)
-            cached = (all_conflict_nodes, vec_conflicts)
-            conflict_mask_cache[cache_key] = cached
+            cached = tuple(set(sibling_nodes + lineage_conflict_nodes))
+            conflict_nodes_cache[cache_key] = cached
+        return cached
+
+    def build_conflict_vector(conflict_nodes):
+        conflict_key = tuple(conflict_nodes)
+        cached = conflict_vector_cache.get(conflict_key)
+        if cached is not None:
+            return cached
+
+        vec_conflicts = np.zeros(len(matrix_index), dtype=bool)
+        for conflict in conflict_nodes:
+            np.logical_or(vec_conflicts, get_m_current_bool(conflict), out=vec_conflicts)
+        conflict_vector_cache[conflict_key] = vec_conflicts
+        return vec_conflicts
+
+    def get_full_chain(anchor_name):
+        cached = full_chain_cache.get(anchor_name)
+        if cached is None:
+            cached = get_full_mutnode_chain_with_anchor(anchor_name, parent_dict)
+            full_chain_cache[anchor_name] = cached
+        return cached
+
+    def get_i_selected_vector(mutation):
+        cached = i_selected_cache.get(mutation)
+        if cached is None:
+            cached = I_selected[mutation].replace({pd.NA: np.nan})
+            i_selected_cache[mutation] = cached
+        return cached
+
+    def get_i_selected_array(mutation):
+        cached = i_selected_array_cache.get(mutation)
+        if cached is None:
+            cached = pd.to_numeric(get_i_selected_vector(mutation).reindex(matrix_index), errors="coerce").to_numpy(
+                dtype=np.float64,
+                na_value=np.nan,
+            )
+            i_selected_array_cache[mutation] = cached
+        return cached
+
+    def get_p_selected_vector(mutation):
+        cached = p_selected_cache.get(mutation)
+        if cached is None:
+            cached = P_selected[mutation]
+            p_selected_cache[mutation] = cached
+        return cached
+
+    def get_mutations_on_node(node_name):
+        cached = node_mutations_cache.get(node_name)
+        if cached is None:
+            cached = tuple(node_name.split("|"))
+            node_mutations_cache[node_name] = cached
+        return cached
+
+    def get_cell_set(node_name):
+        cached = cell_set_cache.get(node_name)
+        if cached is None:
+            cached = set(matrix_index[get_m_current_bool(node_name)])
+            cell_set_cache[node_name] = cached
+        return cached
+
+    def get_children(node_name):
+        cached = children_cache.get(node_name)
+        if cached is None:
+            cached = find_children_of_node(node_name, matrix_columns, parent_dict)
+            children_cache[node_name] = cached
         return cached
         
     # 计算突变的特征用于动态调整惩罚
-    input_binary_vec_full = I_selected[new_mut].replace({pd.NA: np.nan})
+    input_binary_vec_full = new_mut_input_vector
     na_ratio = input_binary_vec_full.isna().mean()
     mut_ratio = input_binary_vec_full.fillna(0).mean()
     N_nodes_beforeT = len(T_current.all_nodes())
@@ -1430,7 +1679,7 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         anchor = pos['anchor']
         
         # 默认 imputed vector
-        imputed_vec = pd.Series(0, index=M_current.index)
+        imputed_bool = np.zeros(len(matrix_index), dtype=bool)
         merge_penalty = 0
         
         # -------------------------
@@ -1438,62 +1687,63 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         # -------------------------
         if placement_type == 'on_node':
             parent = anchor
-            vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] != new_mut])
-            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
+            all_conflict_nodes = get_conflict_nodes(parent, sibling_nodes)
+            vec_conflicts = build_conflict_vector(all_conflict_nodes)
             
             # 正确的逻辑：现有节点的向量与清理后的new_mut合并
-            new_mut_cleaned = new_mut_mask & ~vec_conflicts
-            imputed_vec = (M_current[anchor] | new_mut_cleaned).astype(int)
+            anchor_mask = np.ones(len(matrix_index), dtype=bool) if anchor == 'ROOT' else get_m_current_bool(anchor)
+            new_mut_cleaned = new_mut_mask_array & ~vec_conflicts
+            imputed_bool = anchor_mask | new_mut_cleaned
             N_nodes = N_nodes_beforeT + 1
             
         elif placement_type == 'new_leaf':
             parent = anchor
-            vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] != new_mut])
-            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
+            all_conflict_nodes = get_conflict_nodes(parent, sibling_nodes)
+            vec_conflicts = build_conflict_vector(all_conflict_nodes)
             
             # 正确的逻辑：先排除所有冲突，再与parent交集
-            new_mut_cleaned = new_mut_mask & ~vec_conflicts
-            imputed_vec = new_mut_cleaned.astype(int)
+            new_mut_cleaned = new_mut_mask_array & ~vec_conflicts
+            imputed_bool = new_mut_cleaned
             N_nodes = N_nodes_beforeT + 2
             
         elif placement_type == 'on_edge':
             parent = anchor
             child = pos['meta']['child']
-            vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
-            vec_child = M_current[child]
+            vec_child = get_m_current_bool(child)
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] not in [child, new_mut]])
-            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes)
+            all_conflict_nodes = get_conflict_nodes(parent, sibling_nodes)
+            vec_conflicts = build_conflict_vector(all_conflict_nodes)
             
             # 正确的逻辑：child ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_mask & ~vec_conflicts
-            imputed_vec = (vec_child | new_mut_cleaned).astype(int)
+            new_mut_cleaned = new_mut_mask_array & ~vec_conflicts
+            imputed_bool = vec_child | new_mut_cleaned
             N_nodes = N_nodes_beforeT + 2
             
         elif placement_type == 'new_parent_merge':
             parent = anchor
             merge_children = pos['meta']['merge_children']
-            vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 构建children的联合向量
-            vec_children = pd.Series(0, index=M_current.index)
+            vec_children = np.zeros(len(matrix_index), dtype=bool)
             for c in merge_children:
-                vec_children |= M_current[c]
+                np.logical_or(vec_children, get_m_current_bool(c), out=vec_children)
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [n['name'] for n in pos.get('nodes', []) if n['parent'] == parent and n['name'] not in merge_children + [new_mut]])
-            all_conflict_nodes, vec_conflicts = get_conflict_nodes(parent, sibling_nodes, exclude_nodes=merge_children)
+            all_conflict_nodes = get_conflict_nodes(parent, sibling_nodes, exclude_nodes=merge_children)
+            vec_conflicts = build_conflict_vector(all_conflict_nodes)
             
             # 正确的逻辑：children ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_mask & ~vec_conflicts
-            imputed_vec = (vec_children | new_mut_cleaned).astype(int)
+            new_mut_cleaned = new_mut_mask_array & ~vec_conflicts
+            imputed_bool = vec_children | new_mut_cleaned
             merge_penalty = np.log(len(merge_children)) * 0.5
             N_nodes = N_nodes_beforeT + 2
             
@@ -1504,11 +1754,12 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         # 计算完整突变链的总罚分
         # -------------------------
         # 获取从锚点到ROOT的完整突变链
-        full_mutnode_chain = get_full_mutnode_chain_with_anchor(anchor, parent_dict)
+        full_mutnode_chain = get_full_chain(anchor)
+        imputed_vec = pd.Series(imputed_bool.astype(int, copy=False), index=matrix_index, copy=False)
         
         # 计算new_mut本身的罚分
-        posterior_vec = P_selected[new_mut]
-        input_binary_vec = I_selected[new_mut]
+        posterior_vec = get_p_selected_vector(new_mut)
+        input_binary_vec = get_i_selected_vector(new_mut)
         
         new_mut_penalty, actual_na_flip_ratio, refined_ω_NA, φ_adjusted, weight_na_to_1, weight_na_to_0 = compute_dynamic_penalty(
             input_binary_vec, posterior_vec, imputed_vec, fnfp_ratio, ω_NA, φ,
@@ -1517,37 +1768,32 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         
         # 计算完整突变链中其他突变的罚分
         chain_penalty = 0
-        chain_na_flip_ratio = 0
         chain_mutations_count = 0
         
         for node in full_mutnode_chain:
             if node == 'ROOT':
                 continue
             
-            mutations_on_node = node.split("|")
+            mutations_on_node = get_mutations_on_node(node)
+            node_values = get_m_current_array(node)
+            cells_to_flip_mask = imputed_bool & ((node_values == 0) | np.isnan(node_values))
+            if not bool(cells_to_flip_mask.any()):
+                continue
+            imputed_ones = np.ones(int(cells_to_flip_mask.sum()), dtype=np.int8)
             
             for mutation in mutations_on_node:
                 if mutation == new_mut:  # 跳过new_mut本身，因为已经计算过了
                     continue
                     
-                # 获取该突变的原始数据
-                mut_input_binary_vec = I_selected[mutation].replace({pd.NA: np.nan})
-                mut_posterior_vec = P_selected[mutation]
-                
-                # 计算该突变在new_mut放置后的新向量
-                # 对于split_full_mutmutation_chain_mutations中的突变，如果它们在final_imputed_vec为1的细胞中当前为0或NA，需要翻转为1
-                mut_new_vec = M_current[node].copy()
-                cells_should_be_1 = imputed_vec[imputed_vec == 1].index
-                # 找出要计算的额外发生翻转的 index
-                cells_to_flip = []
-                for cell in cells_should_be_1:
-                    if mut_new_vec[cell] == 0 or pd.isna(mut_new_vec[cell]):
-                        cells_to_flip.append(cell)
-                        mut_new_vec[cell] = 1
-                
                 # 计算该突变的罚分
+                mut_input_binary_vec = get_i_selected_array(mutation)
                 mut_penalty = compute_bayesian_penalty_each_chain_mut_by_pos(
-                    mut_input_binary_vec[cells_to_flip], mut_posterior_vec[cells_to_flip], mut_new_vec[cells_to_flip], weight_na_to_1, weight_na_to_0, fnfp_ratio
+                    mut_input_binary_vec[cells_to_flip_mask],
+                    None,
+                    imputed_ones,
+                    weight_na_to_1,
+                    weight_na_to_0,
+                    fnfp_ratio,
                 )
                 
                 chain_penalty += mut_penalty
@@ -1570,11 +1816,33 @@ def compute_bayesian_penalty_for_positions_consider_ROOT(
         # 添加基于intersection模式和层级的精细调整
         # -------------------------
         intersection_penalty = compute_intersection_based_penalty(
-            new_mut, pos, intersection_nodes, M_current, I_selected, na_ratio, mut_ratio, actual_na_flip_ratio
+            new_mut,
+            pos,
+            intersection_nodes,
+            M_current,
+            I_selected,
+            na_ratio,
+            mut_ratio,
+            actual_na_flip_ratio,
+            mut_cells=mut_cells_new_mut,
+            anchor_cells_cache=cell_set_cache,
+            non_root_columns_set=non_root_columns_set,
+            column_count=matrix_column_count,
+            log_column_count=log_matrix_column_count,
         )
         
         hierarchy_penalty = compute_hierarchy_penalty(
-            new_mut, pos, M_current, I_selected, parent_dict, na_ratio, mut_ratio, actual_na_flip_ratio
+            new_mut,
+            pos,
+            M_current,
+            I_selected,
+            parent_dict,
+            na_ratio,
+            mut_ratio,
+            actual_na_flip_ratio,
+            mut_cells=mut_cells_new_mut,
+            cell_set_cache=cell_set_cache,
+            children_cache=children_cache,
         )
         
         total_penalty = base_total_penalty + intersection_penalty + hierarchy_penalty
@@ -1830,7 +2098,21 @@ def compute_dynamic_bic_penalty(base_φ, na_ratio, mut_ratio, actual_na_flip_rat
     return max(φ_adjusted, 0.1)  # 确保不会降得太低
 
 
-def compute_intersection_based_penalty(new_mut, position, intersection_nodes, M_current, I_selected, na_ratio, mut_ratio, actual_na_flip_ratio):
+def compute_intersection_based_penalty(
+    new_mut,
+    position,
+    intersection_nodes,
+    M_current,
+    I_selected,
+    na_ratio,
+    mut_ratio,
+    actual_na_flip_ratio,
+    mut_cells=None,
+    anchor_cells_cache=None,
+    non_root_columns_set=None,
+    column_count=None,
+    log_column_count=None,
+):
     """
     根据intersection模式和实际NA翻转调整罚分
     """
@@ -1839,45 +2121,72 @@ def compute_intersection_based_penalty(new_mut, position, intersection_nodes, M_
     anchor = position['anchor']
     
     # 获取new_mut的mutant cells
-    mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    if mut_cells is None:
+        mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    if anchor_cells_cache is None:
+        anchor_cells_cache = {}
+    if non_root_columns_set is None:
+        non_root_columns_set = {n for n in M_current.columns if n != 'ROOT'}
+    if column_count is None:
+        column_count = len(M_current.columns)
+    if log_column_count is None:
+        log_column_count = np.log(column_count)
+
+    def get_anchor_cells(node_name):
+        cached = anchor_cells_cache.get(node_name)
+        if cached is None:
+            cached = set(M_current.index[M_current[node_name] == 1])
+            anchor_cells_cache[node_name] = cached
+        return cached
     
     if placement_type == 'on_node':
-        anchor_cells = set(M_current.index[M_current[anchor] == 1])
+        anchor_cells = get_anchor_cells(anchor)
         
         # 情况1：如果new_mut只与一个节点强相交，但被放在不同的early node
         if len(intersection_nodes) == 1:
             sole_intersection = list(intersection_nodes)[0]
-            if anchor != sole_intersection and anchor in [n for n in M_current.columns if n != 'ROOT']:
+            if anchor != sole_intersection and anchor in non_root_columns_set:
                 # 结合实际翻转比例调整惩罚
                 flip_based_multiplier = 1.0 + actual_na_flip_ratio  # 翻转越多，惩罚越重
-                extra_penalty += np.log(len(M_current.columns)) * 0.8 * flip_based_multiplier
+                extra_penalty += log_column_count * 0.8 * flip_based_multiplier
         
         # 情况2：如果anchor涵盖的细胞远多于new_mut的mutant cells
         if len(anchor_cells) > len(mut_cells) * 3:
             # 结合实际翻转比例调整FN惩罚
             fn_penalty = np.log(len(anchor_cells) - len(mut_cells)) * 0.3
             extra_penalty += fn_penalty * (1.0 + actual_na_flip_ratio)
-            
+        
         # 情况3：高NA突变被放在非相交节点上且实际翻转比例高
         if na_ratio > 0.7 and anchor not in intersection_nodes and actual_na_flip_ratio > 0.3:
-            extra_penalty += np.log(len(M_current.columns)) * 0.5
+            extra_penalty += log_column_count * 0.5
     
     elif placement_type in ['new_leaf', 'on_edge']:
         # 对于高NA小突变且实际翻转比例低的，减少开新节点的惩罚
         if na_ratio > 0.7 and mut_ratio < 0.1 and actual_na_flip_ratio < 0.2:
-            bonus = -np.log(len(M_current.columns)) * 0.4 * (1.0 - actual_na_flip_ratio)
+            bonus = -log_column_count * 0.4 * (1.0 - actual_na_flip_ratio)
             extra_penalty += bonus
             
         # 对于与多个节点相交的突变，减少开新节点的惩罚
         if len(intersection_nodes) >= 2:
-            bonus = -np.log(len(M_current.columns)) * 0.3
+            bonus = -log_column_count * 0.3
             extra_penalty += bonus
     
     return extra_penalty
 
 
-def compute_hierarchy_penalty(new_mut, position, M_current, I_selected, parent_dict, 
-                            na_ratio, mut_ratio, actual_na_flip_ratio):
+def compute_hierarchy_penalty(
+    new_mut,
+    position,
+    M_current,
+    I_selected,
+    parent_dict,
+    na_ratio,
+    mut_ratio,
+    actual_na_flip_ratio,
+    mut_cells=None,
+    cell_set_cache=None,
+    children_cache=None,
+):
     """
     计算层级合理性惩罚，考虑实际NA翻转
     """
@@ -1885,19 +2194,36 @@ def compute_hierarchy_penalty(new_mut, position, M_current, I_selected, parent_d
     placement_type = position['placement_type']
     anchor = position['anchor']
     
-    mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    if mut_cells is None:
+        mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    if cell_set_cache is None:
+        cell_set_cache = {}
+    if children_cache is None:
+        children_cache = {}
+
+    def get_cell_set(node_name):
+        cached = cell_set_cache.get(node_name)
+        if cached is None:
+            cached = set(M_current.index[M_current[node_name] == 1])
+            cell_set_cache[node_name] = cached
+        return cached
+
+    def get_children(node_name):
+        cached = children_cache.get(node_name)
+        if cached is None:
+            cached = find_children_of_node(node_name, M_current.columns, parent_dict)
+            children_cache[node_name] = cached
+        return cached
     
     if placement_type == 'on_node':
-        anchor_cells = set(M_current.index[M_current[anchor] == 1])
-        
         # 检查这个anchor是否有children
-        anchor_children = find_children_of_node(anchor, M_current.columns, parent_dict)
+        anchor_children = get_children(anchor)
         
         if anchor_children:
             # 如果anchor有children，且new_mut与children有特定模式
             children_intersection = False
             for child in anchor_children:
-                child_cells = set(M_current.index[M_current[child] == 1])
+                child_cells = get_cell_set(child)
                 if mut_cells.issubset(child_cells) and len(mut_cells) < len(child_cells) * 0.8:
                     children_intersection = True
                     break
@@ -1909,7 +2235,7 @@ def compute_hierarchy_penalty(new_mut, position, M_current, I_selected, parent_d
     
     elif placement_type == 'new_leaf':
         parent = anchor
-        parent_cells = set(M_current.index[M_current[parent] == 1])
+        parent_cells = get_cell_set(parent)
         
         # 如果new_mut的细胞是parent细胞的真子集，这是一个合理的子克隆
         if mut_cells.issubset(parent_cells) and len(mut_cells) < len(parent_cells) * 0.8:
@@ -3854,11 +4180,25 @@ def attach_mutations_to_current_tree(sorted_attached_mutations, T_current, M_cur
         _log_tree_snapshot(logger, f"Updated tree after mutation {new_mut}:", T_current)
         
         # 检查冲突
-        if scp.ul.is_conflict_free_gusfield(M_current):
+        touched_columns = _resolve_touched_columns_for_conflict_check(
+            final_position,
+            parent_dict,
+            M_current.columns,
+            new_mut,
+        )
+        if _is_conflict_free_local_update(
+            M_current,
+            touched_columns,
+            logger,
+            f"Step6_AttachMutations[{new_mut}]",
+        ):
             logger.info(f"Current M_current is conflict-free and shaped as: {M_current.shape}")
         else:
             raise ValueError(f"Current M_current is conflict !!! Break!!!.")
-    
+
+    if not _is_conflict_free_gusfield_safe(M_current, logger, "Step6_AttachMutations[final]"):
+        raise ValueError("Current M_current failed final conflict validation.")
+
     return external_mutations, T_current, M_current, root_mutations
 
 # # 调用函数
@@ -3994,11 +4334,25 @@ def process_rescue_mutations(sorted_rescue_mutations, T_current, M_current, I_at
         _log_tree_snapshot(logger, f"Updated tree after mutation {new_mut}:", T_current)
         
         # 检查冲突
-        if scp.ul.is_conflict_free_gusfield(M_current):
+        touched_columns = _resolve_touched_columns_for_conflict_check(
+            final_position,
+            parent_dict,
+            M_current.columns,
+            new_mut,
+        )
+        if _is_conflict_free_local_update(
+            M_current,
+            touched_columns,
+            logger,
+            f"Step6_RescueMutations[{new_mut}]",
+        ):
             logger.info(f"Current M_current is conflict-free and shaped as: {M_current.shape}")
         else:
             raise ValueError(f"Current M_current is conflict !!! Break!!!.")
-    
+
+    if not _is_conflict_free_gusfield_safe(M_current, logger, "Step6_RescueMutations[final]"):
+        raise ValueError("Current M_current failed final conflict validation.")
+
     return external_mutations, T_current, M_current, root_mutations
 
 # # 调用函数
@@ -4089,6 +4443,7 @@ def process_external_mutations_by_subtree_groups(
                 final_position = generate_new_leaf_on_root(T_current, subtree_mut)
                 T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
+                touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []
             
             else:
                 
@@ -4142,11 +4497,22 @@ def process_external_mutations_by_subtree_groups(
                 else:
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
+                touched_columns = _resolve_touched_columns_for_conflict_check(
+                    final_position,
+                    parent_dict,
+                    M_current.columns,
+                    subtree_mut,
+                )
             
             _log_tree_snapshot(logger, f"Tree after adding {subtree_mut}:", T_current)
             
             # 检查冲突
-            if not scp.ul.is_conflict_free_gusfield(M_current):
+            if not _is_conflict_free_local_update(
+                M_current,
+                touched_columns,
+                logger,
+                f"Step6_SubtreeGroup[{subtree_mut}]",
+            ):
                 logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")
                 
                 # 回滚操作：从矩阵中移除这个突变
@@ -4220,11 +4586,22 @@ def process_external_mutations_by_subtree_groups(
                 else:
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
+                touched_columns = _resolve_touched_columns_for_conflict_check(
+                    final_position,
+                    parent_dict,
+                    M_current.columns,
+                    subtree_mut,
+                )
                 
                 _log_tree_snapshot(logger, f"Updated tree after re-attaching mutation {subtree_mut}:", T_current)
                 
                 # 检查冲突
-                if not scp.ul.is_conflict_free_gusfield(M_current):
+                if not _is_conflict_free_local_update(
+                    M_current,
+                    touched_columns,
+                    logger,
+                    f"Step6_SubtreeReattach[{subtree_mut}]",
+                ):
                     logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")
                     
                     # 回滚操作：从矩阵中移除这个突变
@@ -4253,10 +4630,16 @@ def process_external_mutations_by_subtree_groups(
         final_position = generate_new_leaf_on_root(T_current, subtree_mut)
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         M_current[subtree_mut] = I_attached[subtree_mut].fillna(0).astype(int)
+        touched_columns = [subtree_mut] if subtree_mut in M_current.columns else []
         
         _log_tree_snapshot(logger, f"Tree after adding singleton {subtree_mut}:", T_current)
         
-        if not scp.ul.is_conflict_free_gusfield(M_current):
+        if not _is_conflict_free_local_update(
+            M_current,
+            touched_columns,
+            logger,
+            f"Step6_SubtreeSingleton[{subtree_mut}]",
+        ):
             logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")
             
             # 回滚操作：从矩阵中移除这个突变
@@ -4270,6 +4653,9 @@ def process_external_mutations_by_subtree_groups(
     
     logger.info("All external mutations have been processed successfully.")
     logger.info(f"Remained mutations count: {len(remained_mutations)}")
+
+    if not _is_conflict_free_gusfield_safe(M_current, logger, "Step6_SubtreeGroups[final]"):
+        raise ValueError("Current M_current failed final conflict validation.")
     
     return remained_mutations, T_current, M_current, root_mutations
 

--- a/src/run_phylosilid_fullTree_scRNA.py
+++ b/src/run_phylosilid_fullTree_scRNA.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import sys
 os.environ['PYTHONHASHSEED'] = '42'
 
 
@@ -20,6 +21,7 @@ start_time = time.perf_counter()
 import logging
 import copy
 import random
+from concurrent.futures import ThreadPoolExecutor
 import pandas as pd
 import numpy as np
 from tqdm import tqdm
@@ -41,6 +43,103 @@ from src.mutation_integrator import *
 # ------------------------------
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
+def write_bulk_input_from_counts(
+    A: pd.DataFrame,
+    C: pd.DataFrame,
+    output_file: str,
+) -> str:
+    """Build BSCITE bulk input directly from parsed count matrices."""
+    if "bulk" not in A.index or "bulk" not in C.index:
+        raise KeyError(
+            "'bulk' row is required to generate input_BULK.txt. "
+            f"Available rows sample: {list(A.index[:5])}"
+        )
+
+    remaining_cells = [idx for idx in A.index if idx != "bulk"]
+    if not remaining_cells:
+        raise ValueError("No single-cell rows available for BSCITE bulk input generation")
+
+    sample3 = deterministic_choice(remaining_cells, salt="scRNA_bulk_sample")
+    pseudo_alt = A.sum(axis=0).astype(np.int64)
+    pseudo_total = C.sum(axis=0).astype(np.int64)
+    bulk_alt = A.loc["bulk"].astype(np.int64)
+    bulk_total = C.loc["bulk"].astype(np.int64)
+    sample_alt = A.loc[sample3].astype(np.int64)
+    sample_total = C.loc[sample3].astype(np.int64)
+
+    output_bulk_data = []
+    for i, snp_name in enumerate(A.columns):
+        chromosome, position = get_random_chromosome_position(snp_name)
+        output_bulk_data.append({
+            "ID": f"mut{i}",
+            "Chromosome": chromosome,
+            "Position": position,
+            "MutantCount": f"{pseudo_alt[snp_name]};{bulk_alt[snp_name]};{sample_alt[snp_name]}",
+            "ReferenceCount": f"{pseudo_total[snp_name]};{bulk_total[snp_name]};{sample_total[snp_name]}",
+        })
+
+    pd.DataFrame(output_bulk_data).to_csv(output_file, sep="\t", index=False)
+    return sample3
+
+def write_int_matrix_tsv(
+    output_file: str,
+    row_labels,
+    col_labels,
+    values: np.ndarray,
+) -> None:
+    """Write an integer matrix to TSV faster than pandas.to_csv for dense matrices."""
+    if sys.gettrace() is not None:
+        array_to_write = np.empty((values.shape[0], values.shape[1] + 1), dtype=object)
+        array_to_write[:, 0] = row_labels
+        array_to_write[:, 1:] = values.astype(str, copy=False)
+        with open(output_file, "w", encoding="utf-8", buffering=1024 * 1024) as fh:
+            fh.write("\t" + "\t".join(map(str, col_labels)) + "\n")
+            np.savetxt(fh, array_to_write, fmt="%s", delimiter="\t")
+        return
+
+    value_bytes = [str(i).encode("utf-8") for i in range(10)]
+    encoded_rows = [str(label).encode("utf-8") for label in row_labels]
+    encoded_cols = [str(label).encode("utf-8") for label in col_labels]
+    header = b"\t" + b"\t".join(encoded_cols) + b"\n"
+    with open(output_file, "wb", buffering=1024 * 1024) as fh:
+        fh.write(header)
+        for label, row in zip(encoded_rows, values):
+            fh.write(label)
+            fh.write(b"\t")
+            fh.write(b"\t".join(value_bytes[int(v)] for v in row))
+            fh.write(b"\n")
+
+def export_i_raw_matrices(
+    I_raw: pd.DataFrame,
+    outputpath: str,
+    export_workers: int = 2,
+) -> None:
+    """Export Step1 binary matrices using numpy-backed writers."""
+    raw_values = I_raw.to_numpy(copy=False)
+    missing_mask = np.isnan(raw_values)
+    values_na0 = np.where(missing_mask, 0, raw_values).astype(np.int8, copy=False)
+    values_na3 = np.where(missing_mask, 3, raw_values).astype(np.int8, copy=False)
+    row_labels = I_raw.index.to_numpy(dtype=str)
+    col_labels = I_raw.columns.to_numpy(dtype=str)
+
+    tasks = [
+        (os.path.join(outputpath, "I_raw_withNA0.txt"), row_labels, col_labels, values_na0),
+        (os.path.join(outputpath, "I_raw_withNA0_T.txt"), col_labels, row_labels, values_na0.T),
+        (os.path.join(outputpath, "I_raw_withNA3.txt"), row_labels, col_labels, values_na3),
+        (os.path.join(outputpath, "I_raw_withNA3_T.txt"), col_labels, row_labels, values_na3.T),
+    ]
+
+    worker_count = max(1, min(int(export_workers), len(tasks)))
+    if worker_count == 1:
+        for task in tasks:
+            write_int_matrix_tsv(*task)
+        return
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(write_int_matrix_tsv, *task) for task in tasks]
+        for future in futures:
+            future.result()
+
 # ------------------------------
 # 项目参数与文件路径设置
 # ------------------------------
@@ -58,6 +157,8 @@ parser.add_argument("--is_predict_germ", default="no", choices=["yes", "no"], ty
 parser.add_argument("--is_detect_passtree_by_dp", default="no", choices=["yes", "no"], type=str, help="Select 'yes' or 'no' to determine whether to run Dynamic programing step.")
 parser.add_argument("--is_filter_quality", default="yes", choices=["yes", "no"], type=str, help="Select 'yes' or 'no' to determine whether to filter mutations in scaffold steps by coverage quality.")
 parser.add_argument("--seed", default=42, type=int, help="Random seed for reproducibility")
+parser.add_argument("--load_workers", default=None, type=int, help="Worker threads for Step1 allele-count parsing. Omit to auto-select.")
+parser.add_argument("--export_workers", default=2, type=int, help="Worker threads for Step1 matrix export.")
 
 args = parser.parse_args()
 
@@ -97,6 +198,8 @@ logger.info(f"features_file: {features_file}")
 logger.info(f"is_predict_germ: {is_predict_germ}")
 logger.info(f"is_detect_passtree_by_dp: {is_detect_passtree_by_dp}")
 logger.info(f"is_filter_quality: {is_filter_quality}")
+logger.info(f"load_workers: {args.load_workers if args.load_workers else 'auto'}")
+logger.info(f"export_workers: {args.export_workers}")
 
 
 # ------------------------------
@@ -182,8 +285,9 @@ params = SETTING_PARAMS
 # Step 1: Load data
 # ------------------------------
 logger.info("===== Step1: Loading data ...")
-data = load_all(inputpath)
+data = load_all(inputpath, load_workers=args.load_workers)
 P_raw, V_raw, C_raw, A_raw = data["P"], data["V"], data["C"], data["A"]
+C_raw_reads, A_raw_reads = data["C_raw_reads"], data["A_raw_reads"]
 df_features = data['features']
 df_reads_raw = data['df_reads']
 I_raw = build_binary_I(P_raw, V_raw, C_raw, params["p_thresh"])
@@ -191,95 +295,15 @@ I_raw = build_binary_I(P_raw, V_raw, C_raw, params["p_thresh"])
 logger.info(f"Loaded data: {len(P_raw)} cells, {len(I_raw.columns)} mutations")
 
 ##### Output binary matrix with NA=0
-I_raw_withNA0 = I_raw.replace({np.nan: 0}).astype(int)
-I_raw_withNA0.to_csv(os.path.join(outputpath, "I_raw_withNA0.txt"), sep="\t")
-I_raw_withNA0_T = I_raw_withNA0.T
-I_raw_withNA0_T.to_csv(os.path.join(outputpath, "I_raw_withNA0_T.txt"), sep="\t")
-
-I_raw_withNA3 = I_raw.replace({np.nan: 3}).astype(int)
-I_raw_withNA3.to_csv(os.path.join(outputpath, "I_raw_withNA3.txt"), sep="\t")
-I_raw_withNA3_T = I_raw_withNA3.T
-I_raw_withNA3_T.to_csv(os.path.join(outputpath, "I_raw_withNA3_T.txt"), sep="\t")
+export_i_raw_matrices(I_raw, outputpath, export_workers=args.export_workers)
 
 ##### Output for BSCITE bulk input
-# 获取 pseudo bulk 数据
-df_corrected = df_reads_raw.copy()
-
-# 分割数据并转换为数值
-def split_and_sum(series):
-    before_sum = 0
-    after_sum = 0
-    
-    for value in series:
-        if pd.notna(value) and '/' in str(value):
-            parts = str(value).split('/')
-            if len(parts) == 2:
-                try:
-                    before_sum += int(parts[0])
-                    after_sum += int(parts[1])
-                except ValueError:
-                    continue
-                    
-    return f"{before_sum}/{after_sum}"
-
-# 对每一列应用函数
-for col in df_corrected.columns:
-    df_corrected.loc['pseudo_bulk', col] = split_and_sum(df_corrected[col])
-
-# 产生 bulk input file
-output_bulk_data = []
-
-# 选择三个样本：pseudo_bulk, bulk, 和一个随机细胞
-sample1 = 'pseudo_bulk'
-sample2 = 'bulk'
-
-# 从剩下的细胞中随机选一个（排除pseudo_bulk和bulk）
-remaining_cells = [idx for idx in df_corrected.index if idx not in ['pseudo_bulk', 'bulk']]
-sample3 = deterministic_choice(remaining_cells, salt="scRNA_bulk_sample")
-
-print(f"使用样本: {sample1}, {sample2}, {sample3}")
-
-for i, snp_name in enumerate(df_corrected.columns):
-    # 获取三个样本的数据
-    sample1_value = df_corrected.loc[sample1, snp_name]
-    sample2_value = df_corrected.loc[sample2, snp_name] 
-    sample3_value = df_corrected.loc[sample3, snp_name]
-    
-    samples_mutant = []
-    samples_reference = []
-    
-    # 处理每个样本的数据
-    for value in [sample1_value, sample2_value, sample3_value]:
-        if pd.isna(value):
-            # 如果数据缺失，使用0/0
-            samples_mutant.append(0)
-            samples_reference.append(0)
-        elif '/' in str(value):
-            mutant, reference = str(value).split('/')
-            samples_mutant.append(int(mutant))
-            samples_reference.append(int(reference))
-        else:
-            # 如果格式不对，使用0/0
-            samples_mutant.append(0)
-            samples_reference.append(0)
-    
-    # 组合三个样本的数据
-    mutant_counts = f"{samples_mutant[0]};{samples_mutant[1]};{samples_mutant[2]}"
-    reference_counts = f"{samples_reference[0]};{samples_reference[1]};{samples_reference[2]}"
-    
-    # 获取染色体和位置信息
-    chromosome, position = get_random_chromosome_position(snp_name)
-    
-    output_bulk_data.append({
-        'ID': f'mut{i}',
-        'Chromosome': chromosome,
-        'Position': position,
-        'MutantCount': mutant_counts,
-        'ReferenceCount': reference_counts
-    })
-
-output_bulk_df = pd.DataFrame(output_bulk_data)
-output_bulk_df.to_csv(os.path.join(outputpath, "input_BULK.txt"), sep='\t', index=False)
+sample3 = write_bulk_input_from_counts(
+    A=A_raw_reads,
+    C=C_raw_reads,
+    output_file=os.path.join(outputpath, "input_BULK.txt"),
+)
+logger.info("Using samples for BSCITE bulk input: pseudo_bulk, bulk, %s", sample3)
 
 
 ##### 去掉所有没有 1 的行/细胞

--- a/src/run_phylosilid_fullTree_scRNA.py
+++ b/src/run_phylosilid_fullTree_scRNA.py
@@ -1293,6 +1293,11 @@ if len(external_mutations_fpfnratio_across_tree) > 0:
 
 logging.info(f"The number of final_external_mutations_fpfnratio_across_tree is: {len(final_external_mutations_fpfnratio_across_tree)}")
 
+step66_rehang_attempted = bool(
+    sorted_rehanged_mutations_all_fpfnratio_across_tree
+    or sorted_fn_mutations_fpfnratio_across_tree
+)
+
 T_test = copy.deepcopy(T_current)
 M_test = M_current.copy()
 M_test = M_test.drop(columns=['ROOT'], errors='ignore')
@@ -1306,14 +1311,18 @@ final_cleaned_M_test.shape
 
 
 ##### 计算 T_current 中每一个 mutations 的 fp_ratio 和 fn_ratio (across tree)
-T_checkpoint_fpfnratio_across_tree_v2 = copy.deepcopy(T_current)
-M_checkpoint_fpfnratio_across_tree_v2 = M_current.copy()
+if step66_rehang_attempted:
+    T_checkpoint_fpfnratio_across_tree_v2 = copy.deepcopy(T_current)
+    M_checkpoint_fpfnratio_across_tree_v2 = M_current.copy()
 
-M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2 = M_checkpoint_fpfnratio_across_tree_v2.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_current_fpfnratio_across_tree_v2 = M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2 = split_merged_columns(M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, mutations_on_T_current_fpfnratio_across_tree_v2)
+    M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2 = M_checkpoint_fpfnratio_across_tree_v2.drop(columns=['ROOT'], errors='ignore')
+    mutations_on_T_current_fpfnratio_across_tree_v2 = M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
+    M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2 = split_merged_columns(M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, mutations_on_T_current_fpfnratio_across_tree_v2)
 
-df_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, fp_mutations_dict_fpfnratio_across_tree_v2 = calculate_fp_fn_ratios_across_tree(M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, I_attached)
+    df_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, fp_mutations_dict_fpfnratio_across_tree_v2 = calculate_fp_fn_ratios_across_tree(M_for_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2, I_attached)
+else:
+    df_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2 = df_fp_ratio_and_fn_ratio_fpfnratio_across_tree.copy()
+    fp_mutations_dict_fpfnratio_across_tree_v2 = fp_mutations_dict_fpfnratio_across_tree.copy()
 df_fp_ratio_and_fn_ratio_fpfnratio_across_tree_v2
 #              identifier  fp_ratio  fn_ratio
 # 0     chr17_7578893_G_T  0.362069  0.760684

--- a/src/run_phylosilid_fullTree_scRNA.py
+++ b/src/run_phylosilid_fullTree_scRNA.py
@@ -634,15 +634,6 @@ external_mutations_of_attached_on_scaffold, T_current, M_current, root_mutations
 )
 logging.info(f"The number of external_mutations_of_attached_on_scaffold is: {len(external_mutations_of_attached_on_scaffold)}")
 
-T_test = copy.deepcopy(T_current)
-M_test = M_current.copy()
-M_test = M_test.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_test = M_test.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_test = split_merged_columns(M_test, mutations_on_T_test)
-final_cleaned_M_test = M_test.loc[(M_test != 0).any(axis=1)]  # 移除全0行
-final_cleaned_M_test.shape
-# (1184, 34)
-
 
 
 
@@ -650,12 +641,6 @@ final_cleaned_M_test.shape
 # Step6.2: 处理 external_mutations_of_attached_on_scaffold, 也就是第一次在树上找不到 intersection 的 mut 再挂一次
 # -----------------------------
 logger.info("===== Step6.2: Handle 'external_mutations_of_attached_on_scaffold' after first hang mutations ...")
-
-##### external_mutations_of_attached_on_scaffold
-len(external_mutations_of_attached_on_scaffold)
-# 11
-print(external_mutations_of_attached_on_scaffold)
-# ['chr11_47268814_C_A', 'chr22_22895482_G_A', 'chr2_55866672_T_A', 'chr15_64953013_C_T', 'chr22_34670933_A_T', 'chr9_114311431_A_T', 'chr1_5862839_A_T', 'chr12_6451607_T_C', 'chr14_105707803_C_A', 'chr16_69117490_C_T', 'chr22_50526071_G_A']
 
 ##### 主处理流程，把第一次挂树没挂上的 external_mutations 重新挂一遍
 sorted_external_mutations_of_attached_on_scaffold = [i for i in I_attached.columns if i in external_mutations_of_attached_on_scaffold]
@@ -671,15 +656,6 @@ final_external_mutations_of_attached_on_scaffold, T_current, M_current, root_mut
     logger=logger,
     root_mutations=root_mutations  # 可选，如果已有根突变列表
 )
-
-T_test = copy.deepcopy(T_current)
-M_test = M_current.copy()
-M_test = M_test.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_test = M_test.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_test = split_merged_columns(M_test, mutations_on_T_test)
-final_cleaned_M_test = M_test.loc[(M_test != 0).any(axis=1)]  # 移除全0行
-final_cleaned_M_test.shape
-# (1184, 34)
 
 
 
@@ -714,15 +690,6 @@ if len(external_mutations) > 0:
         root_mutations=root_mutations  # 可选，如果已有根突变列表
     )
 
-T_test = copy.deepcopy(T_current)
-M_test = M_current.copy()
-M_test = M_test.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_test = M_test.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_test = split_merged_columns(M_test, mutations_on_T_test)
-final_cleaned_M_test = M_test.loc[(M_test != 0).any(axis=1)]  # 移除全0行
-final_cleaned_M_test.shape
-# (1184, 34)
-
 
 ##### 最后还没挂上的突变只能上 ROOT 了
 logging.info(f"The number of final_external_mutations is: {len(final_external_mutations)}")
@@ -746,15 +713,6 @@ if len(final_external_mutations)>0:
         logger=logger,
         root_mutations=root_mutations
     )
-
-T_test = copy.deepcopy(T_current)
-M_test = M_current.copy()
-M_test = M_test.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_test = M_test.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_test = split_merged_columns(M_test, mutations_on_T_test)
-final_cleaned_M_test = M_test.loc[(M_test != 0).any(axis=1)]  # 移除全0行
-final_cleaned_M_test.shape
-# (1184, 34)
 
 
 
@@ -784,18 +742,6 @@ if len(remained_mutations) > 0:
     )
 
 logging.info(f"The number of final_remained_mutations is: {len(final_remained_mutations)}")
-
-T_test = copy.deepcopy(T_current)
-M_test = M_current.copy()
-M_test = M_test.drop(columns=['ROOT'], errors='ignore')
-mutations_on_T_test = M_test.columns.to_series().apply(lambda x: x.split("|")).explode().unique().tolist()
-M_test = split_merged_columns(M_test, mutations_on_T_test)
-final_cleaned_M_test = M_test.loc[(M_test != 0).any(axis=1)]  # 移除全0行
-final_cleaned_M_test.shape
-# (1184, 34)
-
-
-print(T_current)
 # └─ ROOT
 #   └─ chr17_7578893_G_T
 #     └─ chr8_80170791_C_T|chr7_20381814_G_T

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -96,6 +96,37 @@ def _build_conflict_mask(matrix, conflict_nodes, index):
     return vec_conflicts
 
 
+def _build_scaffold_lineage_fill_update(final_position, final_imputed_vec, parent_dict):
+    if final_position is None or final_imputed_vec is None:
+        return {"mutation_chain": (), "cells": ()}
+
+    mutation_chain = tuple(get_full_mutnode_chain_with_anchor_scaffold(final_position["anchor"], parent_dict))
+    cells = tuple(final_imputed_vec.index[final_imputed_vec == 1].tolist())
+    return {
+        "mutation_chain": mutation_chain,
+        "cells": cells,
+    }
+
+
+def _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update):
+    mutation_chain = lineage_fill_update.get("mutation_chain", ())
+    cells = lineage_fill_update.get("cells", ())
+
+    if not mutation_chain or not cells:
+        return M_current
+
+    cells_list = list(cells)
+    for mutation in mutation_chain:
+        if mutation not in M_current.columns:
+            continue
+        column_values = M_current.loc[cells_list, mutation]
+        cells_to_update = column_values.index[column_values == 0]
+        if len(cells_to_update) > 0:
+            M_current.loc[cells_to_update, mutation] = 1
+
+    return M_current
+
+
 
 
 def get_random_chromosome_position(snp_name):
@@ -3648,15 +3679,15 @@ def compute_bayesian_penalty_for_positions_scaffold(
     new_mut, selected_positions, T_current, M_current, I_selected, P_selected, parent_dict, intersection_nodes, 
     ω_NA=0.001, fnfp_ratio=0.1, φ=1
 ):
-    import copy
     import pandas as pd
     import numpy as np
     results = []
+    empty_lineage_fill_update = {"mutation_chain": (), "cells": ()}
     
     # 如果没有候选位置，直接返回 None
     if len(selected_positions) == 0:
         logger.warning(f"No selected positions for mutation {new_mut}")
-        return None, None, pd.DataFrame(), M_current
+        return None, None, pd.DataFrame(), empty_lineage_fill_update
     
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
     new_mut_mask = _as_bool_mask(new_mut_bin_vector, M_current.index)
@@ -3945,7 +3976,8 @@ def compute_bayesian_penalty_for_positions_scaffold(
             'φ_adjusted': φ_adjusted,
             'base_ω_NA': ω_NA,
             'base_φ': φ,
-            'full_mutnode_chain': full_mutnode_chain
+            'full_mutnode_chain': full_mutnode_chain,
+            'imputed_sum': int(imputed_vec.sum()),
         })
     
     # 初始化df_penalty避免作用域问题
@@ -3957,69 +3989,43 @@ def compute_bayesian_penalty_for_positions_scaffold(
         # -------------------------
         if len(results) == 0:
             logger.warning(f"No valid results for mutation {new_mut}")
-            return None, None, pd.DataFrame(), M_current
+            return None, None, pd.DataFrame(), empty_lineage_fill_update
         
         df_penalty = pd.DataFrame(results)
         
         # 检查 DataFrame 是否为空
         if df_penalty.empty:
             logger.warning(f"Empty penalty DataFrame for mutation {new_mut}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 检查 total_penalty 列是否存在
         if 'total_penalty' not in df_penalty.columns:
             logger.warning(f"total_penalty column missing for mutation {new_mut}. Columns: {df_penalty.columns.tolist()}")
-            return None, None, df_penalty, M_current
+            return None, None, df_penalty, empty_lineage_fill_update
         
         # 检查 total_penalty 列是否有有效值
         if df_penalty['total_penalty'].isna().all():
             logger.warning(f"All total_penalty values are NaN for mutation {new_mut}")
-            return None, None, df_penalty, M_current
-        
-        # 查找最小 penalty 并检查 imputed_vec 是否全为 0
-        valid_results = []
-        for idx, row in df_penalty.iterrows():
-            if row['imputed_vec'].sum() == 0:
-                logger.info(f"Skipping position with all imputed_vec values as 0: {row['position']}")
-                continue
-            valid_results.append(row)
-        
-        if not valid_results:
+            return None, None, df_penalty, empty_lineage_fill_update
+
+        df_valid_penalty = df_penalty[df_penalty['imputed_sum'] > 0]
+        if df_valid_penalty.empty:
             logger.warning(f"No valid results (with non-zero imputed_vec) for mutation {new_mut}")
-            return None, None, df_penalty, M_current
-        
+            return None, None, df_penalty, empty_lineage_fill_update
+
         # 选择最小 penalty 的有效位置
-        df_valid_penalty = pd.DataFrame(valid_results)
         min_idx = df_valid_penalty['base_total_penalty'].idxmin()
         min_row = df_valid_penalty.loc[min_idx]
         
         final_position = min_row['position']
         final_imputed_vec = min_row['imputed_vec'].copy()
         
-        # -------------------------
-        # 修正：改进的M_current更新逻辑
-        # -------------------------
-        anchor = final_position['anchor']
-        
-        # 获取从锚点到ROOT的完整突变链
-        full_mutnode_chain = get_full_mutnode_chain_with_anchor_scaffold(anchor, parent_dict)
-        
-        # 找出所有在final_imputed_vec中为1的细胞
-        cells_with_final_one = final_imputed_vec[final_imputed_vec == 1].index.tolist()
-        
-        if len(cells_with_final_one) > 0:
-            # 对于每个在final_imputed_vec中为1的细胞，确保其父节点链也为1
-            for cell in cells_with_final_one:
-                for mutation in full_mutnode_chain:
-                    # 只有当该突变当前为0时才填充为1
-                    if M_current.loc[cell, mutation] == 0:
-                        M_current.loc[cell, mutation] = 1
-        
-        return final_position, final_imputed_vec.astype(int), df_penalty, M_current
+        lineage_fill_update = _build_scaffold_lineage_fill_update(final_position, final_imputed_vec, parent_dict)
+        return final_position, final_imputed_vec.astype(int), df_penalty, lineage_fill_update
     
     except Exception as e:
         logger.warning(f"Error selecting minimum penalty for mutation {new_mut}: {e}")
-        return None, None, df_penalty, M_current
+        return None, None, df_penalty, empty_lineage_fill_update
 
 
 def get_all_conflict_nodes_outside_lineage_scaffold(anchor, parent_dict, all_columns, exclude_nodes=None):
@@ -4629,10 +4635,15 @@ def integrate_mutations_to_scaffold_within_group(sorted_attached_mutations, T_cu
             continue
                 
         # 计算贝叶斯罚分并更新 M_current
-        final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_scaffold(
+        final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_scaffold(
             new_mut, refined_positions, T_current, M_current, I_attached, P_attached, parent_dict, intersection_nodes, 
             ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
         )
+        if final_position is None or final_imputed_vec is None:
+            external_mutations.append(new_mut)
+            logger.warning(f"Mutation {new_mut} added to external_mutations (no valid scoring result)")
+            continue
+        M_current = _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update)
         logger.info(f"The new_mut should be placed on position: {final_position['placement_type']}.")
         
         # 更新 M_current
@@ -4708,9 +4719,6 @@ def process_subtree_mutations_to_specific_node(
         current_group_start_node = None
         reattached_mutations = []
         for idx, subtree_mut in enumerate(tqdm(sorted_group, desc="Processing mutations in group")):
-            T_rollback = copy.deepcopy(T_current)
-            M_rollback = M_current.copy()
-            
             logger.info(f"Processing mutation {idx+1}/{len(sorted_group)}: {subtree_mut}")
             
             if idx == 0:
@@ -4724,10 +4732,17 @@ def process_subtree_mutations_to_specific_node(
                 parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
                 potential_positions = [p for i,p in enumerate(candidate_positions) if p['placement_type'] == 'new_leaf']
                 # T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position_list[0])
-                final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_scaffold(
+                final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_scaffold(
                     subtree_mut, potential_positions, T_current, M_current, I_selected, P_selected, parent_dict, set(list(intersection_nodes)+target_node_names), 
                     ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
                 )
+                if final_position is None or final_imputed_vec is None:
+                    reattached_mutations.append(subtree_mut)
+                    logger.info(f"Mutation {subtree_mut} added to reattached_mutations (no valid scoring result)")
+                    continue
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
+                M_current = _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update)
                 M_current[subtree_mut] = final_imputed_vec
                 T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 
@@ -4758,10 +4773,17 @@ def process_subtree_mutations_to_specific_node(
                     continue
                 
                 # 计算贝叶斯罚分并更新 M_current
-                final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_scaffold(
+                final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_scaffold(
                     subtree_mut, potential_positions, T_current, M_current, I_selected, P_selected, parent_dict, subtree_nodes, 
                     ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
                 )
+                if final_position is None or final_imputed_vec is None:
+                    reattached_mutations.append(subtree_mut)
+                    logger.info(f"Mutation {subtree_mut} added to reattached_mutations (no valid scoring result)")
+                    continue
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
+                M_current = _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update)
                 logger.info(f"Mutation {subtree_mut} should be placed on position: {final_position['placement_type']}")
                 
                 # 更新 M_current
@@ -4802,9 +4824,6 @@ def process_subtree_mutations_to_specific_node(
             
             sorted_reattached_mutations = [i for i in I_selected.columns if i in reattached_mutations]
             for subtree_mut in tqdm(sorted_reattached_mutations, desc="Processing re-attached mutations"):
-                T_rollback = copy.deepcopy(T_current)
-                M_rollback = M_current.copy()
-                
                 logger.info(f"Processing re-attached mutation: {subtree_mut}")
                 
                 # 仍然从当前组的起始节点开始搜索
@@ -4827,10 +4846,17 @@ def process_subtree_mutations_to_specific_node(
                     continue
                                 
                 # 计算贝叶斯罚分并更新 M_current
-                final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_scaffold(
+                final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_scaffold(
                     subtree_mut, potential_positions, T_current, M_current, I_selected, P_selected, parent_dict, subtree_nodes, 
                     ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
                 )
+                if final_position is None or final_imputed_vec is None:
+                    second_reattached_mutations.append(subtree_mut)
+                    logger.info(f"Mutation {subtree_mut} added to second_reattached_mutations (no valid scoring result)")
+                    continue
+                T_rollback = copy.deepcopy(T_current)
+                M_rollback = M_current.copy()
+                M_current = _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update)
                 logger.info(f"The subtree_mut should be placed on position: {final_position['placement_type']}.")
                 
                 if final_position['placement_type'] == 'on_node':
@@ -4868,9 +4894,6 @@ def process_subtree_mutations_to_specific_node(
     logger.info(f"Processing {len(singleton_subtree_groups)} singleton groups")
     # for group_idx, group in enumerate(tqdm(singleton_subtree_groups, desc="Processing singleton subtrees")):
     for group in tqdm(singleton_subtree_groups, desc="Processing singleton subtrees"):
-        T_rollback = copy.deepcopy(T_current)
-        M_rollback = M_current.copy()
-        
         subtree_mut = group[0]
         logger.info(f"Attaching singleton mutation directly to target node {target_node_names}: {subtree_mut}")
                 
@@ -4889,10 +4912,17 @@ def process_subtree_mutations_to_specific_node(
         parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
         potential_positions = [p for i,p in enumerate(candidate_positions) if p['placement_type'] == 'new_leaf']
         # T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position_list[0])
-        final_position, final_imputed_vec, df_penalty_score, M_current = compute_bayesian_penalty_for_positions_scaffold(
+        final_position, final_imputed_vec, df_penalty_score, lineage_fill_update = compute_bayesian_penalty_for_positions_scaffold(
             subtree_mut, potential_positions, T_current, M_current, I_selected, P_selected, parent_dict, set(list(intersection_nodes)+target_node_names), 
             ω_NA=ω_NA, fnfp_ratio=fnfp_ratio, φ=φ
         )
+        if final_position is None or final_imputed_vec is None:
+            external_mutations.append(subtree_mut)
+            logger.info(f"Mutation {subtree_mut} added to external_mutations (no valid scoring result)")
+            continue
+        T_rollback = copy.deepcopy(T_current)
+        M_rollback = M_current.copy()
+        M_current = _apply_scaffold_lineage_fill_to_matrix(M_current, lineage_fill_update)
         M_current[subtree_mut] = final_imputed_vec
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -2791,19 +2791,19 @@ def split_merged_columns(merged_matrix: pd.DataFrame, mut_list: list):
     """
     根据mut_list拆分合并的列
     """
-    out = {}
-    for mut in mut_list:
-        # 找到包含该mutation的合并列
-        found = False
-        for merged_col in merged_matrix.columns:
-            if mut in merged_col.split("|"):
-                out[mut] = merged_matrix[merged_col].copy()
-                found = True
-                break
-        if not found:
-            # 如果没找到，创建全NA列
-            out[mut] = pd.Series([pd.NA] * len(merged_matrix), index=merged_matrix.index)
-    
+    mutation_to_merged_col = {}
+    for merged_col in merged_matrix.columns:
+        for mutation in merged_col.split("|"):
+            mutation_to_merged_col.setdefault(mutation, merged_col)
+
+    missing_series = pd.Series(pd.NA, index=merged_matrix.index)
+    out = {
+        mut: merged_matrix[mutation_to_merged_col[mut]]
+        if mut in mutation_to_merged_col
+        else missing_series
+        for mut in mut_list
+    }
+
     return pd.DataFrame(out, index=merged_matrix.index)[mut_list]
 
 # # 测试数据

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -3661,8 +3661,16 @@ def compute_bayesian_penalty_for_positions_scaffold(
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
     new_mut_mask = _as_bool_mask(new_mut_bin_vector, M_current.index)
     new_mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    matrix_columns = M_current.columns
     positive_cells_cache = {}
     children_cache = {}
+    lineage_parent_cache = {}
+    lineage_conflict_cache = {}
+    conflict_mask_cache = {}
+    full_chain_cache = {}
+    mutation_input_cache = {new_mut: I_selected[new_mut].replace({pd.NA: np.nan})}
+    mutation_posterior_cache = {new_mut: P_selected[new_mut]}
+    node_mutations_cache = {}
     non_root_columns = [col for col in M_current.columns if col != 'ROOT']
 
     def get_positive_cells(column_name):
@@ -3678,9 +3686,72 @@ def compute_bayesian_penalty_for_positions_scaffold(
             cached = find_children_of_node_scaffold(anchor_name, M_current.columns, parent_dict)
             children_cache[anchor_name] = cached
         return cached
+
+    def get_lineage_parent(anchor_name):
+        cached = lineage_parent_cache.get(anchor_name)
+        if cached is None:
+            cached = build_lineage_parent_dict_from_tree(T_current, anchor_name)
+            lineage_parent_cache[anchor_name] = cached
+        return cached
+
+    def get_lineage_conflict_nodes(anchor_name, exclude_nodes=()):
+        exclude_key = tuple(exclude_nodes) if exclude_nodes else ()
+        cache_key = (anchor_name, exclude_key)
+        cached = lineage_conflict_cache.get(cache_key)
+        if cached is None:
+            cached = tuple(
+                get_all_conflict_nodes_outside_lineage_scaffold(
+                    anchor_name,
+                    get_lineage_parent(anchor_name),
+                    matrix_columns,
+                    list(exclude_key),
+                )
+            )
+            lineage_conflict_cache[cache_key] = cached
+        return cached
+
+    def get_conflict_mask(anchor_name, sibling_nodes, exclude_nodes=()):
+        sibling_key = tuple(sibling_nodes) if sibling_nodes else ()
+        exclude_key = tuple(exclude_nodes) if exclude_nodes else ()
+        cache_key = (anchor_name, sibling_key, exclude_key)
+        cached = conflict_mask_cache.get(cache_key)
+        if cached is None:
+            lineage_conflict_nodes = get_lineage_conflict_nodes(anchor_name, exclude_key)
+            all_conflict_nodes = list(set(sibling_key + lineage_conflict_nodes))
+            cached = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
+            conflict_mask_cache[cache_key] = cached
+        return cached
+
+    def get_full_chain(anchor_name):
+        cached = full_chain_cache.get(anchor_name)
+        if cached is None:
+            cached = tuple(get_full_mutnode_chain_with_anchor_scaffold(anchor_name, parent_dict))
+            full_chain_cache[anchor_name] = cached
+        return cached
+
+    def get_mutation_input(mutation_name):
+        cached = mutation_input_cache.get(mutation_name)
+        if cached is None:
+            cached = I_selected[mutation_name].replace({pd.NA: np.nan})
+            mutation_input_cache[mutation_name] = cached
+        return cached
+
+    def get_mutation_posterior(mutation_name):
+        cached = mutation_posterior_cache.get(mutation_name)
+        if cached is None:
+            cached = P_selected[mutation_name]
+            mutation_posterior_cache[mutation_name] = cached
+        return cached
+
+    def get_node_mutations(node_name):
+        cached = node_mutations_cache.get(node_name)
+        if cached is None:
+            cached = tuple(node_name.split("|"))
+            node_mutations_cache[node_name] = cached
+        return cached
     
     # 计算突变的特征用于动态调整惩罚
-    input_binary_vec_full = I_selected[new_mut].replace({pd.NA: np.nan})
+    input_binary_vec_full = mutation_input_cache[new_mut]
     na_ratio = input_binary_vec_full.isna().mean()
     mut_ratio = input_binary_vec_full.fillna(0).mean()
     N_nodes_beforeT = len(T_current.all_nodes())
@@ -3703,15 +3774,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [])
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
+            vec_conflicts = get_conflict_mask(parent, sibling_nodes)
             
             # 正确的逻辑：现有节点的向量与清理后的new_mut合并
             new_mut_cleaned = new_mut_mask & ~vec_conflicts
@@ -3724,15 +3787,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [])
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
+            vec_conflicts = get_conflict_mask(parent, sibling_nodes)
             
             # 正确的逻辑：先排除所有冲突，再与parent交集
             new_mut_cleaned = new_mut_mask & ~vec_conflicts
@@ -3747,15 +3802,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [])
-            
-            # 获取lineage之外的所有冲突节点
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
+            vec_conflicts = get_conflict_mask(parent, sibling_nodes)
             
             # 正确的逻辑：child ∪ (清理后的new_mut ∩ parent)
             new_mut_cleaned = new_mut_mask & ~vec_conflicts
@@ -3774,15 +3821,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             
             # 获取直系sibling冲突节点
             sibling_nodes = pos.get('sibling_nodes', [])
-            
-            # 获取lineage之外的所有冲突节点（排除merge_children）
-            lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns, exclude_nodes=merge_children)
-            
-            # 合并所有冲突节点（去重）
-            all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
-            
-            # 构建冲突向量
-            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
+            vec_conflicts = get_conflict_mask(parent, sibling_nodes, merge_children)
             
             # 正确的逻辑：children ∪ (清理后的new_mut ∩ parent)
             new_mut_cleaned = new_mut_mask & ~vec_conflicts
@@ -3797,11 +3836,12 @@ def compute_bayesian_penalty_for_positions_scaffold(
         # 计算完整突变链的总罚分
         # -------------------------
         # 获取从锚点到ROOT的完整突变链
-        full_mutnode_chain = get_full_mutnode_chain_with_anchor_scaffold(anchor, parent_dict)
+        full_mutnode_chain = get_full_chain(anchor)
         
         # 计算new_mut本身的罚分
-        posterior_vec = P_selected[new_mut]
+        posterior_vec = mutation_posterior_cache[new_mut]
         input_binary_vec = I_selected[new_mut]
+        cells_should_be_1 = imputed_vec[imputed_vec == 1].index
         
         # 基于实际NA翻转比例计算惩罚
         new_mut_penalty, actual_na_flip_ratio, refined_ω_NA, φ_adjusted, weight_na_to_1, weight_na_to_0 = compute_dynamic_penalty_scaffold(
@@ -3818,21 +3858,20 @@ def compute_bayesian_penalty_for_positions_scaffold(
             if node == 'ROOT':
                 continue
             
-            mutations_on_node = node.split("|")
+            mutations_on_node = get_node_mutations(node)
             
             for mutation in mutations_on_node:
                 if mutation == new_mut:  # 跳过new_mut本身，因为已经计算过了
                     continue
                     
                 # 获取该突变的原始数据
-                mut_input_binary_vec = I_selected[mutation].replace({pd.NA: np.nan})
-                mut_posterior_vec = P_selected[mutation]
+                mut_input_binary_vec = get_mutation_input(mutation)
+                mut_posterior_vec = get_mutation_posterior(mutation)
                 chain_mutations_count += 1
                 
                 # 计算该突变在new_mut放置后的新向量
                 # 对于split_full_mutmutation_chain_mutations中的突变，如果它们在final_imputed_vec为1的细胞中当前为0或NA，需要翻转为1
                 mut_new_vec = M_current[node].copy()
-                cells_should_be_1 = imputed_vec[imputed_vec == 1].index
                 # 找出要计算的额外发生翻转的 index
                 cells_to_flip = []
                 for cell in cells_should_be_1:

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -69,6 +69,14 @@ except ImportError:
         community_louvain = None
 
 logger = logging.getLogger(__name__)
+_VERBOSE_TREE_UPDATES = os.environ.get("PHYLOSOLID_VERBOSE_TREES", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _log_tree_snapshot(active_logger, label, tree):
+    if not _VERBOSE_TREE_UPDATES:
+        return
+    active_logger.info(label)
+    print_tree(tree)
 
 
 def _as_bool_mask(series, index):
@@ -2861,23 +2869,35 @@ def split_merged_columns(merged_matrix: pd.DataFrame, mut_list: list):
 # 配置日志
 logger = logging.getLogger(__name__)
 
-def find_intersection_positions_within_group_directly(T_current: TreeNode, new_mut: str, matrix, mutation_group, min_overlap=1):
+def find_intersection_positions_within_group_directly(
+    T_current: TreeNode,
+    new_mut: str,
+    matrix,
+    mutation_group,
+    min_overlap=1,
+    intersection_nodes=None,
+    tree_parent_dict=None,
+    node_lookup=None,
+    matrix_positive=None,
+):
     """
     基于交集分析的优化版本，直接找到相关位置，只考虑与当前 mutation 同一组的 clone 下的节点
     """
     # 1. 找到所有与目标突变有交集的节点
-    intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
-        T_current, matrix, new_mut, min_overlap
-    )
+    if intersection_nodes is None:
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+            T_current, matrix, new_mut, min_overlap, matrix_positive=matrix_positive
+        )
     
-    logger.info(f"Found {len(intersection_nodes)} intersection nodes for {new_mut}: {intersection_nodes}")
+    logger.debug("Found %s intersection nodes for %s", len(intersection_nodes), new_mut)
     
     if len(intersection_nodes) == 0:
         logger.debug(f"No intersection nodes found for {new_mut}")
         return []  # 没有交集，返回空列表
     
     # 2. 构建树的父子关系字典
-    tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+    if tree_parent_dict is None:
+        tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
     
     # 3. 获取新突变所在的组
     target_group = mutation_group[new_mut]
@@ -2885,16 +2905,19 @@ def find_intersection_positions_within_group_directly(T_current: TreeNode, new_m
     # 4. 找到所有相关路径上的节点，仅限于同一组的 clone 路径
     all_path_nodes = get_all_path_nodes_with_group_filter(intersection_nodes, tree_parent_dict, mutation_group, target_group)
     
-    logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut} in the same mutation group {target_group}")
+    logger.debug("Found %s path nodes for %s in mutation group %s", len(all_path_nodes), new_mut, target_group)
     
     # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
+    if node_lookup is None:
+        node_lookup = {node.name: node for node in T_current.traverse()}
+
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             continue
             
-        node = T_current.find(node_name)
+        node = node_lookup.get(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
@@ -2920,40 +2943,55 @@ def find_intersection_positions_within_group_directly(T_current: TreeNode, new_m
                     for combo in combinations(path_children, r):
                         candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
-    logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
+    logger.debug("Generated %s candidate positions for %s", len(candidate_positions), new_mut)
     return candidate_positions
 
 
-def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, matrix, target_node, min_overlap=1):
+def find_new_leaf_positions_for_target_node(
+    T_current: TreeNode,
+    new_mut: str,
+    matrix,
+    target_node,
+    min_overlap=1,
+    intersection_nodes=None,
+    tree_parent_dict=None,
+    node_lookup=None,
+    matrix_positive=None,
+):
     """
     基于交集分析的优化版本，但只返回与目标节点相关的 new_leaf position
     """
     # 1. 找到所有与目标突变有交集的节点
-    intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
-        T_current, matrix, new_mut, min_overlap
-    )
+    if intersection_nodes is None:
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+            T_current, matrix, new_mut, min_overlap, matrix_positive=matrix_positive
+        )
     
-    logger.info(f"Found {len(intersection_nodes)} intersection nodes for {new_mut}: {intersection_nodes}")
+    logger.debug("Found %s intersection nodes for %s", len(intersection_nodes), new_mut)
     
     if len(intersection_nodes) == 0:
         logger.debug(f"No intersection nodes found for {new_mut}")
         return []  # 没有交集，返回空列表
     
     # 2. 构建树的父子关系字典
-    tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+    if tree_parent_dict is None:
+        tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
     
     # 3. 找到所有相关路径上的节点
     all_path_nodes = find_all_path_nodes_scaffold(intersection_nodes, tree_parent_dict)
     
-    logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut}")
+    logger.debug("Found %s path nodes for %s", len(all_path_nodes), new_mut)
     
     # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
+    if node_lookup is None:
+        node_lookup = {node.name: node for node in T_current.traverse()}
+
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             # 保留 ROOT 上的 on_node 类型的 position
-            node = T_current.find(node_name)
+            node = node_lookup.get(node_name)
             if node is None:
                 logger.warning(f"Node {node_name} not found in tree")
                 continue
@@ -2963,7 +3001,7 @@ def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, m
             
             continue  # ROOT 的其他类型位置仍然跳过
         
-        node = T_current.find(node_name)
+        node = node_lookup.get(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
@@ -2989,7 +3027,7 @@ def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, m
                     for combo in combinations(path_children, r):
                         candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
-    logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
+    logger.debug("Generated %s candidate positions for %s", len(candidate_positions), new_mut)
     
     # 6. 筛选出 anchor 是 target_node 且 placement_type 是 new_leaf 的 position
     target_positions = [
@@ -2997,41 +3035,55 @@ def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, m
         if pos['placement_type'] == 'new_leaf' and pos['anchor'] == target_node.name
     ]
     
-    logger.info(f"Filtered to {len(target_positions)} target positions for {new_mut} under node {target_node.name}")
+    logger.debug("Filtered to %s target positions for %s under node %s", len(target_positions), new_mut, target_node.name)
     
     return target_positions
 
 
-def find_intersection_positions_within_tree_directly_scaffold(T_current: TreeNode, new_mut: str, matrix, min_overlap=1):
+def find_intersection_positions_within_tree_directly_scaffold(
+    T_current: TreeNode,
+    new_mut: str,
+    matrix,
+    min_overlap=1,
+    intersection_nodes=None,
+    tree_parent_dict=None,
+    node_lookup=None,
+    matrix_positive=None,
+):
     """
     基于交集分析的优化版本，直接找到相关位置
     """
     # 1. 找到所有与目标突变有交集的节点
-    intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
-        T_current, matrix, new_mut, min_overlap
-    )
+    if intersection_nodes is None:
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+            T_current, matrix, new_mut, min_overlap, matrix_positive=matrix_positive
+        )
     
-    logger.info(f"Found {len(intersection_nodes)} intersection nodes for {new_mut}: {intersection_nodes}")
+    logger.debug("Found %s intersection nodes for %s", len(intersection_nodes), new_mut)
     
     if len(intersection_nodes) == 0:
         logger.debug(f"No intersection nodes found for {new_mut}")
         return []  # 没有交集，返回空列表
     
     # 2. 构建树的父子关系字典
-    tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+    if tree_parent_dict is None:
+        tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
     
     # 3. 找到所有相关路径上的节点
     all_path_nodes = find_all_path_nodes_scaffold(intersection_nodes, tree_parent_dict)
     
-    logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut}")
+    logger.debug("Found %s path nodes for %s", len(all_path_nodes), new_mut)
     
     # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
+    if node_lookup is None:
+        node_lookup = {node.name: node for node in T_current.traverse()}
+
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             # 保留 ROOT 上的 on_node 类型的 position
-            node = T_current.find(node_name)
+            node = node_lookup.get(node_name)
             if node is None:
                 logger.warning(f"Node {node_name} not found in tree")
                 continue
@@ -3041,7 +3093,7 @@ def find_intersection_positions_within_tree_directly_scaffold(T_current: TreeNod
             
             continue  # ROOT 的其他类型位置仍然跳过
         
-        node = T_current.find(node_name)
+        node = node_lookup.get(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
@@ -3067,7 +3119,7 @@ def find_intersection_positions_within_tree_directly_scaffold(T_current: TreeNod
                     for combo in combinations(path_children, r):
                         candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
-    logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
+    logger.debug("Generated %s candidate positions for %s", len(candidate_positions), new_mut)
     return candidate_positions
 
 def filter_candidate_positions_from_target_node(candidate_positions, subtree_nodes):
@@ -3276,11 +3328,22 @@ def build_lineage_parent_dict_from_tree(tree, anchor):
     
 #     return intersect_muts
 
-def find_all_intersect_muts_from_tree_by_matrix_scaffold(tree, matrix, target_mut, min_overlap=1):
+def find_all_intersect_muts_from_tree_by_matrix_scaffold(tree, matrix, target_mut, min_overlap=1, matrix_positive=None):
     """
     返回所有与 target_mut 在 matrix 中有至少 min_overlap 个细胞共同出现的树节点集合。
     """
     intersect_nodes = set()
+    if target_mut not in matrix.columns:
+        return intersect_nodes
+
+    if matrix_positive is None:
+        matrix_positive = matrix.reindex(index=matrix.index).eq(1).fillna(False)
+
+    target_positive = matrix_positive[target_mut]
+    if not bool(target_positive.any()):
+        return intersect_nodes
+
+    overlap_counts = matrix_positive.loc[target_positive].sum(axis=0)
     
     # 遍历所有节点（除 ROOT）
     for node in tree.all_nodes():
@@ -3294,16 +3357,11 @@ def find_all_intersect_muts_from_tree_by_matrix_scaffold(tree, matrix, target_mu
             if mut == target_mut:
                 continue  # 跳过自身
             
-            if mut not in matrix.columns or target_mut not in matrix.columns:
+            if mut not in overlap_counts.index:
                 continue  # 确保突变存在于矩阵中
-            
-            # 计算两突变的共现数量
-            mut_vec = matrix[mut].fillna(0)
-            target_vec = matrix[target_mut].fillna(0)
-            N11 = ((mut_vec == 1) & (target_vec == 1)).sum()
-            
+
             # 如果任何一个突变有足够的共现，就标记这个节点
-            if N11 >= min_overlap:
+            if int(overlap_counts[mut]) >= min_overlap:
                 has_intersection = True
                 break  # 只要节点中有一个突变有交集就够了
         
@@ -3683,6 +3741,9 @@ def compute_bayesian_penalty_for_positions_scaffold(
     import numpy as np
     results = []
     empty_lineage_fill_update = {"mutation_chain": (), "cells": ()}
+    best_result = None
+    valid_result_count = 0
+    matrix_index = M_current.index
     
     # 如果没有候选位置，直接返回 None
     if len(selected_positions) == 0:
@@ -3699,7 +3760,14 @@ def compute_bayesian_penalty_for_positions_scaffold(
     lineage_conflict_cache = {}
     conflict_mask_cache = {}
     full_chain_cache = {}
+    m_current_array_cache = {}
     mutation_input_cache = {new_mut: I_selected[new_mut].replace({pd.NA: np.nan})}
+    mutation_input_array_cache = {
+        new_mut: pd.to_numeric(mutation_input_cache[new_mut].reindex(matrix_index), errors="coerce").to_numpy(
+            dtype=np.float64,
+            na_value=np.nan,
+        )
+    }
     mutation_posterior_cache = {new_mut: P_selected[new_mut]}
     node_mutations_cache = {}
     non_root_columns = [col for col in M_current.columns if col != 'ROOT']
@@ -3760,11 +3828,31 @@ def compute_bayesian_penalty_for_positions_scaffold(
             full_chain_cache[anchor_name] = cached
         return cached
 
+    def get_m_current_array(column_name):
+        cached = m_current_array_cache.get(column_name)
+        if cached is None:
+            cached = pd.to_numeric(M_current[column_name].reindex(matrix_index), errors="coerce").to_numpy(
+                dtype=np.float64,
+                na_value=np.nan,
+            )
+            m_current_array_cache[column_name] = cached
+        return cached
+
     def get_mutation_input(mutation_name):
         cached = mutation_input_cache.get(mutation_name)
         if cached is None:
             cached = I_selected[mutation_name].replace({pd.NA: np.nan})
             mutation_input_cache[mutation_name] = cached
+        return cached
+
+    def get_mutation_input_array(mutation_name):
+        cached = mutation_input_array_cache.get(mutation_name)
+        if cached is None:
+            cached = pd.to_numeric(get_mutation_input(mutation_name).reindex(matrix_index), errors="coerce").to_numpy(
+                dtype=np.float64,
+                na_value=np.nan,
+            )
+            mutation_input_array_cache[mutation_name] = cached
         return cached
 
     def get_mutation_posterior(mutation_name):
@@ -3872,7 +3960,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
         # 计算new_mut本身的罚分
         posterior_vec = mutation_posterior_cache[new_mut]
         input_binary_vec = I_selected[new_mut]
-        cells_should_be_1 = imputed_vec[imputed_vec == 1].index
+        imputed_bool = imputed_vec.to_numpy(dtype=bool, copy=False)
         
         # 基于实际NA翻转比例计算惩罚
         new_mut_penalty, actual_na_flip_ratio, refined_ω_NA, φ_adjusted, weight_na_to_1, weight_na_to_0 = compute_dynamic_penalty_scaffold(
@@ -3890,29 +3978,27 @@ def compute_bayesian_penalty_for_positions_scaffold(
                 continue
             
             mutations_on_node = get_node_mutations(node)
+            scored_mutations = tuple(mutation for mutation in mutations_on_node if mutation != new_mut)
+            chain_mutations_count += len(scored_mutations)
+            if not scored_mutations:
+                continue
+
+            node_values = get_m_current_array(node)
+            cells_to_flip_mask = imputed_bool & ((node_values == 0) | np.isnan(node_values))
+            if not bool(cells_to_flip_mask.any()):
+                continue
+            imputed_ones = np.ones(int(cells_to_flip_mask.sum()), dtype=np.int8)
             
-            for mutation in mutations_on_node:
-                if mutation == new_mut:  # 跳过new_mut本身，因为已经计算过了
-                    continue
-                    
+            for mutation in scored_mutations:
                 # 获取该突变的原始数据
-                mut_input_binary_vec = get_mutation_input(mutation)
-                mut_posterior_vec = get_mutation_posterior(mutation)
-                chain_mutations_count += 1
-                
-                # 计算该突变在new_mut放置后的新向量
-                # 对于split_full_mutmutation_chain_mutations中的突变，如果它们在final_imputed_vec为1的细胞中当前为0或NA，需要翻转为1
-                mut_new_vec = M_current[node].copy()
-                # 找出要计算的额外发生翻转的 index
-                cells_to_flip = []
-                for cell in cells_should_be_1:
-                    if mut_new_vec[cell] == 0 or pd.isna(mut_new_vec[cell]):
-                        cells_to_flip.append(cell)
-                        mut_new_vec[cell] = 1
-                
-                # 计算该突变的罚分
+                mut_input_binary_vec = get_mutation_input_array(mutation)
                 mut_penalty = compute_bayesian_penalty_each_chain_mut_by_pos(
-                    mut_input_binary_vec[cells_to_flip], mut_posterior_vec[cells_to_flip], mut_new_vec[cells_to_flip], weight_na_to_1, weight_na_to_0, fnfp_ratio
+                    mut_input_binary_vec[cells_to_flip_mask],
+                    None,
+                    imputed_ones,
+                    weight_na_to_1,
+                    weight_na_to_0,
+                    fnfp_ratio,
                 )
                 
                 chain_penalty += mut_penalty
@@ -3948,7 +4034,8 @@ def compute_bayesian_penalty_for_positions_scaffold(
         
         total_penalty = base_total_penalty + intersection_penalty + hierarchy_penalty
         
-        results.append({
+        imputed_sum = int(imputed_vec.sum())
+        result_row = {
             'position_index': idx,
             'placement_type': placement_type,
             'anchor': anchor,
@@ -3964,8 +4051,6 @@ def compute_bayesian_penalty_for_positions_scaffold(
             'intersection_penalty': intersection_penalty,
             'hierarchy_penalty': hierarchy_penalty,
             'total_penalty': total_penalty,
-            'position': pos,
-            'imputed_vec': imputed_vec,
             'na_ratio': na_ratio,
             'mut_ratio': mut_ratio,
             'actual_na_flip_ratio': actual_na_flip_ratio,
@@ -3976,9 +4061,21 @@ def compute_bayesian_penalty_for_positions_scaffold(
             'φ_adjusted': φ_adjusted,
             'base_ω_NA': ω_NA,
             'base_φ': φ,
-            'full_mutnode_chain': full_mutnode_chain,
-            'imputed_sum': int(imputed_vec.sum()),
-        })
+            'imputed_sum': imputed_sum,
+        }
+        results.append(result_row)
+
+        if imputed_sum <= 0:
+            continue
+
+        valid_result_count += 1
+        if best_result is None or base_total_penalty < best_result['base_total_penalty']:
+            best_result = {
+                'position': pos,
+                'imputed_vec': imputed_vec,
+                'full_mutnode_chain': full_mutnode_chain,
+                'base_total_penalty': base_total_penalty,
+            }
     
     # 初始化df_penalty避免作用域问题
     df_penalty = pd.DataFrame()
@@ -4008,18 +4105,13 @@ def compute_bayesian_penalty_for_positions_scaffold(
             logger.warning(f"All total_penalty values are NaN for mutation {new_mut}")
             return None, None, df_penalty, empty_lineage_fill_update
 
-        df_valid_penalty = df_penalty[df_penalty['imputed_sum'] > 0]
-        if df_valid_penalty.empty:
+        if best_result is None or valid_result_count == 0:
             logger.warning(f"No valid results (with non-zero imputed_vec) for mutation {new_mut}")
             return None, None, df_penalty, empty_lineage_fill_update
 
-        # 选择最小 penalty 的有效位置
-        min_idx = df_valid_penalty['base_total_penalty'].idxmin()
-        min_row = df_valid_penalty.loc[min_idx]
-        
-        final_position = min_row['position']
-        final_imputed_vec = min_row['imputed_vec'].copy()
-        
+        final_position = best_result['position']
+        final_imputed_vec = best_result['imputed_vec'].copy()
+
         lineage_fill_update = _build_scaffold_lineage_fill_update(final_position, final_imputed_vec, parent_dict)
         return final_position, final_imputed_vec.astype(int), df_penalty, lineage_fill_update
     
@@ -4613,19 +4705,38 @@ def integrate_mutations_to_scaffold_within_group(sorted_attached_mutations, T_cu
     """
     
     external_mutations = []
+    matrix_index = M_current.index
+    i_attached_positive = I_attached.reindex(index=matrix_index).eq(1).fillna(False)
     
     for new_mut in tqdm(sorted_attached_mutations, desc="Processing mutations", unit="mutation"):
         logger.info(f"Processing mutation: {new_mut}")
         
         # 找到交集节点
-        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(T_current, I_attached, new_mut)
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+            T_current,
+            I_attached,
+            new_mut,
+            matrix_positive=i_attached_positive,
+        )
         if len(intersection_nodes) == 0:
             external_mutations.append(new_mut)
             logger.info(f"Mutation {new_mut} added to external_mutations (no intersection found)")
             continue
         
         # 使用优化方法获取候选位置
-        refined_positions = find_intersection_positions_within_group_directly(T_current, new_mut, I_attached, mutation_group, min_overlap=1)
+        tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+        node_lookup = {node.name: node for node in T_current.traverse()}
+        refined_positions = find_intersection_positions_within_group_directly(
+            T_current,
+            new_mut,
+            I_attached,
+            mutation_group,
+            min_overlap=1,
+            intersection_nodes=intersection_nodes,
+            tree_parent_dict=tree_parent_dict,
+            node_lookup=node_lookup,
+            matrix_positive=i_attached_positive,
+        )
         parent_dict = build_parent_dict_from_candidates_scaffold(refined_positions)
         
         # 检查是否找到候选位置
@@ -4657,8 +4768,7 @@ def integrate_mutations_to_scaffold_within_group(sorted_attached_mutations, T_cu
         T_current = add_new_mutation_to_tree_independent(new_mut, T_current, final_position)
         
         # 打印当前树的结构
-        logger.info(f"Updated tree after mutation {new_mut}:")
-        print_tree(T_current)
+        _log_tree_snapshot(logger, f"Updated tree after mutation {new_mut}:", T_current)
         
         # 检查冲突
         if scp.ul.is_conflict_free_gusfield(M_current):
@@ -4683,6 +4793,7 @@ def process_subtree_mutations_to_specific_node(
         root_mutations = []
     
     external_mutations = []
+    i_selected_positive = I_selected.reindex(index=M_current.index).eq(1).fillna(False)
     
     # 查找目标节点
     if target_node_names is None:
@@ -4705,7 +4816,9 @@ def process_subtree_mutations_to_specific_node(
         # 重排序，把 sorted_group 中跟 T_current 上 node 有交集的突变先放到 list 最前面
         # 简洁版本
         viable_mutations = [mut for mut in sorted_group 
-                           if len(find_all_intersect_muts_from_tree_by_matrix_scaffold(T_current, I_selected, mut)) > 0]
+                           if len(find_all_intersect_muts_from_tree_by_matrix_scaffold(
+                               T_current, I_selected, mut, matrix_positive=i_selected_positive
+                           )) > 0]
         non_viable_mutations = [mut for mut in sorted_group if mut not in viable_mutations]
         
         if not viable_mutations:
@@ -4723,11 +4836,22 @@ def process_subtree_mutations_to_specific_node(
             
             if idx == 0:
                 # 找到 intersection nodes
-                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(T_current, I_selected, subtree_mut)
+                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+                    T_current, I_selected, subtree_mut, matrix_positive=i_selected_positive
+                )
+                tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+                node_lookup = {node.name: node for node in T_current.traverse()}
                 
                 # 第一个 mutation 要在当前最晚 node 上找到罚分更小的 node 挂到目标节点的 new_leaf 上
                 candidate_positions = find_intersection_positions_within_tree_directly_scaffold(
-                    T_current, subtree_mut, I_selected, min_overlap=1
+                    T_current,
+                    subtree_mut,
+                    I_selected,
+                    min_overlap=1,
+                    intersection_nodes=intersection_nodes,
+                    tree_parent_dict=tree_parent_dict,
+                    node_lookup=node_lookup,
+                    matrix_positive=i_selected_positive,
                 )
                 parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
                 potential_positions = [p for i,p in enumerate(candidate_positions) if p['placement_type'] == 'new_leaf']
@@ -4759,8 +4883,20 @@ def process_subtree_mutations_to_specific_node(
                     continue
                 
                 # 使用优化方法获取候选位置（从当前组的起始节点开始）
+                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+                    T_current, I_selected, subtree_mut, matrix_positive=i_selected_positive
+                )
+                tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+                node_lookup = {node.name: node for node in T_current.traverse()}
                 candidate_positions = find_intersection_positions_within_tree_directly_scaffold(
-                    T_current, subtree_mut, I_selected, min_overlap=1
+                    T_current,
+                    subtree_mut,
+                    I_selected,
+                    min_overlap=1,
+                    intersection_nodes=intersection_nodes,
+                    tree_parent_dict=tree_parent_dict,
+                    node_lookup=node_lookup,
+                    matrix_positive=i_selected_positive,
                 )
                 parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
                 subtree_nodes = get_subtree_nodes_tree_node(current_group_start_node)
@@ -4801,8 +4937,7 @@ def process_subtree_mutations_to_specific_node(
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
             
             # 打印当前树结构
-            logger.info(f"Tree after adding {subtree_mut}:")
-            print_tree(T_current)
+            _log_tree_snapshot(logger, f"Tree after adding {subtree_mut}:", T_current)
             
             # 检查冲突
             if not scp.ul.is_conflict_free_gusfield(M_current):
@@ -4833,8 +4968,20 @@ def process_subtree_mutations_to_specific_node(
                     continue
                 
                 # 使用优化方法获取候选位置（从当前组的起始节点开始）
+                intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+                    T_current, I_selected, subtree_mut, matrix_positive=i_selected_positive
+                )
+                tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+                node_lookup = {node.name: node for node in T_current.traverse()}
                 candidate_positions = find_intersection_positions_within_tree_directly_scaffold(
-                    T_current, subtree_mut, I_selected, min_overlap=1
+                    T_current,
+                    subtree_mut,
+                    I_selected,
+                    min_overlap=1,
+                    intersection_nodes=intersection_nodes,
+                    tree_parent_dict=tree_parent_dict,
+                    node_lookup=node_lookup,
+                    matrix_positive=i_selected_positive,
                 )
                 parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
                 subtree_nodes = get_subtree_nodes_tree_node(current_group_start_node)
@@ -4870,8 +5017,7 @@ def process_subtree_mutations_to_specific_node(
                     M_current[subtree_mut] = final_imputed_vec
                     T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
                 
-                logger.info(f"Updated tree after re-attaching mutation {subtree_mut}:")
-                print_tree(T_current)
+                _log_tree_snapshot(logger, f"Updated tree after re-attaching mutation {subtree_mut}:", T_current)
                 
                 if not scp.ul.is_conflict_free_gusfield(M_current):
                     logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")
@@ -4898,7 +5044,9 @@ def process_subtree_mutations_to_specific_node(
         logger.info(f"Attaching singleton mutation directly to target node {target_node_names}: {subtree_mut}")
                 
         # 找到 intersection nodes
-        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(T_current, I_selected, subtree_mut)
+        intersection_nodes = find_all_intersect_muts_from_tree_by_matrix_scaffold(
+            T_current, I_selected, subtree_mut, matrix_positive=i_selected_positive
+        )
         # 检查是否有intersection
         if len(intersection_nodes) == 0:
             logger.warning(f"No intersection found for singleton mutation {subtree_mut}, skipping")
@@ -4906,8 +5054,17 @@ def process_subtree_mutations_to_specific_node(
             continue
         
         # 第一个 mutation 要在当前最晚 node 上找到罚分更小的 node 挂到目标节点的 new_leaf 上
+        tree_parent_dict = build_tree_parent_dict_scaffold(T_current)
+        node_lookup = {node.name: node for node in T_current.traverse()}
         candidate_positions = find_intersection_positions_within_tree_directly_scaffold(
-            T_current, subtree_mut, I_selected, min_overlap=1
+            T_current,
+            subtree_mut,
+            I_selected,
+            min_overlap=1,
+            intersection_nodes=intersection_nodes,
+            tree_parent_dict=tree_parent_dict,
+            node_lookup=node_lookup,
+            matrix_positive=i_selected_positive,
         )
         parent_dict = build_parent_dict_from_candidates_scaffold(candidate_positions)
         potential_positions = [p for i,p in enumerate(candidate_positions) if p['placement_type'] == 'new_leaf']
@@ -4926,8 +5083,7 @@ def process_subtree_mutations_to_specific_node(
         M_current[subtree_mut] = final_imputed_vec
         T_current = add_new_mutation_to_tree_independent(subtree_mut, T_current, final_position)
         
-        logger.info(f"Tree after adding singleton {subtree_mut}:")
-        print_tree(T_current)
+        _log_tree_snapshot(logger, f"Tree after adding singleton {subtree_mut}:", T_current)
         
         if not scp.ul.is_conflict_free_gusfield(M_current):
             logger.warning(f"Conflict detected after adding {subtree_mut}, rolling back")

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -71,6 +71,31 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _as_bool_mask(series, index):
+    aligned = pd.Series(series, index=index) if not isinstance(series, pd.Series) else series.reindex(index)
+    values = aligned.to_numpy(copy=False)
+
+    if np.issubdtype(values.dtype, np.bool_):
+        return pd.Series(values, index=index, copy=False)
+
+    if np.issubdtype(values.dtype, np.integer):
+        return pd.Series(values != 0, index=index)
+
+    if np.issubdtype(values.dtype, np.floating):
+        return pd.Series(np.isfinite(values) & (values != 0), index=index)
+
+    numeric = pd.to_numeric(aligned, errors="coerce")
+    numeric_values = numeric.to_numpy(dtype=np.float64, na_value=np.nan)
+    return pd.Series(np.isfinite(numeric_values) & (numeric_values != 0), index=index)
+
+
+def _build_conflict_mask(matrix, conflict_nodes, index):
+    vec_conflicts = pd.Series(False, index=index)
+    for conflict in conflict_nodes:
+        vec_conflicts |= _as_bool_mask(matrix[conflict], index)
+    return vec_conflicts
+
+
 
 
 def get_random_chromosome_position(snp_name):
@@ -3689,6 +3714,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
         return None, None, pd.DataFrame(), M_current
     
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
+    new_mut_mask = _as_bool_mask(new_mut_bin_vector, M_current.index)
     
     # 计算突变的特征用于动态调整惩罚
     input_binary_vec_full = I_selected[new_mut].replace({pd.NA: np.nan})
@@ -3722,12 +3748,10 @@ def compute_bayesian_penalty_for_positions_scaffold(
             all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
             
             # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
             
             # 正确的逻辑：现有节点的向量与清理后的new_mut合并
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (M_current[anchor] | new_mut_cleaned).astype(int)
             N_nodes = N_nodes_beforeT + 1
             
@@ -3745,12 +3769,10 @@ def compute_bayesian_penalty_for_positions_scaffold(
             all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
             
             # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
             
             # 正确的逻辑：先排除所有冲突，再与parent交集
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = new_mut_cleaned.astype(int)
             N_nodes = N_nodes_beforeT + 2
             
@@ -3770,12 +3792,10 @@ def compute_bayesian_penalty_for_positions_scaffold(
             all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
             
             # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
             
             # 正确的逻辑：child ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (vec_child | new_mut_cleaned).astype(int)
             N_nodes = N_nodes_beforeT + 2
             
@@ -3799,12 +3819,10 @@ def compute_bayesian_penalty_for_positions_scaffold(
             all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
             
             # 构建冲突向量
-            vec_conflicts = pd.Series(0, index=M_current.index)
-            for conflict in all_conflict_nodes:
-                vec_conflicts |= M_current[conflict]
+            vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
             
             # 正确的逻辑：children ∪ (清理后的new_mut ∩ parent)
-            new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+            new_mut_cleaned = new_mut_mask & ~vec_conflicts
             imputed_vec = (vec_children | new_mut_cleaned).astype(int)
             merge_penalty = np.log(len(merge_children)) * 0.5
             N_nodes = N_nodes_beforeT + 2
@@ -4321,6 +4339,7 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
     
     # 获取新突变的二进制向量
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
+    new_mut_mask = _as_bool_mask(new_mut_bin_vector, M_current.index)
     
     # 默认 imputed vector
     imputed_vec = pd.Series(0, index=M_current.index)
@@ -4347,12 +4366,10 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
         all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
         
         # 构建冲突向量
-        vec_conflicts = pd.Series(0, index=M_current.index)
-        for conflict in all_conflict_nodes:
-            vec_conflicts |= M_current[conflict]
+        vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
         
         # 正确的逻辑：先排除所有冲突，再与parent交集
-        new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+        new_mut_cleaned = new_mut_mask & ~vec_conflicts
         imputed_vec = new_mut_cleaned.astype(int)
         
         # 添加新叶子节点
@@ -4375,12 +4392,10 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
         all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
         
         # 构建冲突向量
-        vec_conflicts = pd.Series(0, index=M_current.index)
-        for conflict in all_conflict_nodes:
-            vec_conflicts |= M_current[conflict]
+        vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
         
         # 正确的逻辑：child ∪ (清理后的new_mut ∩ parent)
-        new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+        new_mut_cleaned = new_mut_mask & ~vec_conflicts
         imputed_vec = (vec_child | new_mut_cleaned).astype(int)
         
         # 在边上插入新节点
@@ -4407,12 +4422,10 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
         all_conflict_nodes = list(set(sibling_nodes + lineage_conflict_nodes))
         
         # 构建冲突向量
-        vec_conflicts = pd.Series(0, index=M_current.index)
-        for conflict in all_conflict_nodes:
-            vec_conflicts |= M_current[conflict]
+        vec_conflicts = _build_conflict_mask(M_current, all_conflict_nodes, M_current.index)
         
         # 正确的逻辑：children ∪ (清理后的new_mut ∩ parent)
-        new_mut_cleaned = new_mut_bin_vector & ~vec_conflicts
+        new_mut_cleaned = new_mut_mask & ~vec_conflicts
         imputed_vec = (vec_children | new_mut_cleaned).astype(int)
         
         # 创建新父节点并合并子节点

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -30,6 +30,7 @@ Outputs:
 """
 
 import os
+import shutil
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -493,37 +494,37 @@ def compute_clone_and_pair_weights(muts, corr_cache, n_shuffle=100):
         {tuple(m1,m2): weight}  每个 mutation pair 的权重（只考虑长度≥2的 clone）
     """
     clone_weights = defaultdict(float)  # 全局 clone 权重累加
-    
+    if n_shuffle <= 0:
+        return clone_weights, defaultdict(float)
+
     for ref in muts:
         other_muts = [m for m in muts if m != ref]
         ref_clone_counter = defaultdict(int)  # 记录当前 reference 下每个 clone 的计数
-        
-        for _ in range(n_shuffle):
-            shuffled = list(deterministic_permutation(other_muts))
-            remaining = [ref] + shuffled.copy()
-            
-            while remaining:
-                curr_ref = remaining[0]
-                current_clone = [curr_ref]
-                next_remaining = []
-                
-                for m in remaining[1:]:
-                    key1 = (curr_ref, m)
-                    key2 = (m, curr_ref)
-                    # 检查 corr_cache，避免 KeyError
-                    is_corr = corr_cache.get(key1, corr_cache.get(key2, False))
-                    if is_corr:
-                        current_clone.append(m)
-                    else:
-                        next_remaining.append(m)
-                
-                # 当前 shuffle 的 clone 计数
-                ref_clone_counter[tuple(sorted(current_clone))] += 1
-                remaining = next_remaining
-        
-        # Step: normalize by n_shuffle → clone proportion for this reference
+
+        # 当前实现中的 deterministic_permutation 对同一个输入会返回相同顺序，
+        # 因而重复 n_shuffle 次与执行一次后按比例归一化的结果完全等价。
+        shuffled = list(deterministic_permutation(other_muts))
+        remaining = [ref] + shuffled.copy()
+
+        while remaining:
+            curr_ref = remaining[0]
+            current_clone = [curr_ref]
+            next_remaining = []
+
+            for m in remaining[1:]:
+                key1 = (curr_ref, m)
+                key2 = (m, curr_ref)
+                is_corr = corr_cache.get(key1, corr_cache.get(key2, False))
+                if is_corr:
+                    current_clone.append(m)
+                else:
+                    next_remaining.append(m)
+
+            ref_clone_counter[tuple(sorted(current_clone))] += 1
+            remaining = next_remaining
+
         for clone, count in ref_clone_counter.items():
-            clone_weights[clone] += count / n_shuffle  # 累加到全局
+            clone_weights[clone] += count
     
     # Step: 计算 pair 权重，只考虑长度≥2的 clone
     pair_weights = defaultdict(float)
@@ -539,6 +540,65 @@ from collections import defaultdict
 import itertools
 import numpy as np
 import pandas as pd
+
+def _build_pairwise_correlation_cache_fast(
+    I_S: pd.DataFrame,
+    muts: List[str],
+) -> Tuple[Dict[Tuple[str, str], bool], Dict[str, float], Dict[str, int]]:
+    I_numeric = I_S.loc[:, muts].apply(pd.to_numeric, errors="coerce")
+    values = I_numeric.to_numpy(copy=False)
+
+    ones = np.asarray(values == 1, dtype=np.int32, order="C")
+    zeros = np.asarray(values == 0, dtype=np.int32, order="C")
+
+    n11 = ones.T @ ones
+    n10 = ones.T @ zeros
+    n01 = zeros.T @ ones
+
+    mutant_cell_number_arr = ones.sum(axis=0).astype(np.int32, copy=False)
+    covered_cell_number_arr = (ones + zeros).sum(axis=0).astype(np.int32, copy=False)
+
+    denominator = n11 + n10 + n01
+    jaccard = np.divide(
+        n11,
+        denominator,
+        out=np.zeros_like(n11, dtype=np.float64),
+        where=denominator > 0,
+    )
+    f_forward = np.divide(
+        n11,
+        mutant_cell_number_arr[:, None],
+        out=np.zeros_like(n11, dtype=np.float64),
+        where=mutant_cell_number_arr[:, None] > 0,
+    )
+    f_reverse = np.divide(
+        n11,
+        mutant_cell_number_arr[None, :],
+        out=np.zeros_like(n11, dtype=np.float64),
+        where=mutant_cell_number_arr[None, :] > 0,
+    )
+
+    corr_matrix = (n11 >= 1) & (
+        (jaccard >= 0.08) |
+        ((jaccard > 0) & (jaccard < 0.08) & (np.maximum(f_forward, f_reverse) >= 0.5))
+    )
+    np.fill_diagonal(corr_matrix, True)
+
+    mutant_cell_fraction_arr = np.divide(
+        mutant_cell_number_arr,
+        covered_cell_number_arr,
+        out=np.zeros_like(mutant_cell_number_arr, dtype=np.float64),
+        where=covered_cell_number_arr > 0,
+    )
+
+    corr_cache = {}
+    for i, u in enumerate(muts):
+        for j, v in enumerate(muts):
+            corr_cache[(u, v)] = bool(corr_matrix[i, j])
+
+    mutant_cell_fraction = dict(zip(muts, mutant_cell_fraction_arr))
+    mutant_cell_number = dict(zip(muts, mutant_cell_number_arr))
+    return corr_cache, mutant_cell_fraction, mutant_cell_number
 
 def get_correlation_graph_elements(I_S: pd.DataFrame, n_shuffle: int = 100, seed: int = 42, cutoff_mcf_for_graph: float = 0.05, cutoff_mcn_for_graph: int = 5) -> Tuple[Dict[Tuple[str], float], Dict[Tuple[str,str], float]]:
     """
@@ -559,22 +619,12 @@ def get_correlation_graph_elements(I_S: pd.DataFrame, n_shuffle: int = 100, seed
     n_mut = len(muts)
     
     # Step 1: precompute pairwise correlation cache
-    corr_cache = {}
-    for u, v in itertools.combinations(muts, 2):
-        corr = are_mutations_correlated(I_S, u, v)
-        corr_cache[(u, v)] = corr
-        corr_cache[(v, u)] = corr
-    
-    for m in muts:
-        corr_cache[(m, m)] = True
+    corr_cache, mutant_cell_fraction, mutant_cell_number = _build_pairwise_correlation_cache_fast(I_S, muts)
     
     # Step 2: compute clone weights and pair weights
     clone_weights, pair_weights = compute_clone_and_pair_weights(muts, corr_cache, n_shuffle=n_shuffle)
-    
+
     # Step 3: 计算每个 mutation 的突变 fraction 和突变细胞数
-    mutant_cell_fraction = {mut: I_S[mut].mean(skipna=True) for mut in muts}
-    mutant_cell_number = {mut: I_S[mut].sum(skipna=True) for mut in muts}
-    
     # Step 4: 删除低支持 singleton mutations 对应的 clone
     count = 0
     for mut in muts:
@@ -4419,7 +4469,7 @@ def get_all_conflict_nodes_outside_lineage_scaffold(anchor, parent_dict, all_col
 
 
 def WriteTfile(out_prefix, matrix, rownames, colnames, judge): # writes matrix output as an integer matrix, uses the format given in the documentary. 
-    matrix_output = matrix.astype(int)
+    matrix_output = matrix.replace([np.inf, -np.inf], np.nan).fillna(0).astype(int)
     df_output = pd.DataFrame(matrix_output)
     df_output.index = rownames
     df_output.columns = colnames
@@ -4429,8 +4479,21 @@ def WriteTfile(out_prefix, matrix, rownames, colnames, judge): # writes matrix o
         if is_cf:
             print("Current tree is conflict-free and output binary matrix and plot phylogenetic tree !")
             df_output.to_csv(out_prefix+".CFMatrix", sep="\t")
-            tree = scp.ul.to_tree(df_output)
-            scp.pl.clonal_tree(tree, output_file=out_prefix+".tree_scphylo.pdf")
+            if shutil.which("dot") is None:
+                logger.warning(
+                    "Skipping clonal tree PDF export for %s because Graphviz `dot` is not in PATH.",
+                    out_prefix,
+                )
+            else:
+                try:
+                    tree = scp.ul.to_tree(df_output)
+                    scp.pl.clonal_tree(tree, output_file=out_prefix+".tree_scphylo.pdf")
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to export clonal tree PDF for %s: %s",
+                        out_prefix,
+                        exc,
+                    )
         else:
             print("Current tree is not conflict-free !")
     else:

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -2856,31 +2856,28 @@ def find_intersection_positions_within_group_directly(T_current: TreeNode, new_m
     
     logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut} in the same mutation group {target_group}")
     
-    # 5. 预先创建基础树的深拷贝
-    base_tree_copy = deepcopy(T_current)
-    
-    # 6. 只在这些相关节点上生成候选位置
+    # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             continue
             
-        node = base_tree_copy.find(node_name)
+        node = T_current.find(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
         
         # --- 1) 放在 node 上 ---
-        candidate_positions.append(_create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_on_node_candidate_fast_scaffold(node, new_mut))
         
         # --- 2) 新 leaf ---
-        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(node, new_mut))
         
         # --- 3) 放在每条 edge 上 ---
         for child in node.children:
             if child.name in all_path_nodes:  # 只考虑路径上的子节点
-                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(base_tree_copy, node, child, new_mut))
+                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(node, child, new_mut))
         
         # --- 4) 新 parent merge 多个子节点 ---
         if len(node.children) >= 2:
@@ -2890,7 +2887,7 @@ def find_intersection_positions_within_group_directly(T_current: TreeNode, new_m
                 # 限制组合数量避免爆炸
                 for r in range(2, min(4, len(path_children) + 1)):
                     for combo in combinations(path_children, r):
-                        candidate_positions.append(_create_merge_candidate_fast_scaffold(base_tree_copy, node, combo, new_mut))
+                        candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
     logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
     return candidate_positions
@@ -2919,40 +2916,37 @@ def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, m
     
     logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut}")
     
-    # 4. 预先创建基础树的深拷贝
-    base_tree_copy = deepcopy(T_current)
-    
     # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             # 保留 ROOT 上的 on_node 类型的 position
-            node = base_tree_copy.find(node_name)
+            node = T_current.find(node_name)
             if node is None:
                 logger.warning(f"Node {node_name} not found in tree")
                 continue
             
             # 生成 ROOT 上的 on_node 类型的候选位置
-            candidate_positions.append(_create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+            candidate_positions.append(_create_on_node_candidate_fast_scaffold(node, new_mut))
             
             continue  # ROOT 的其他类型位置仍然跳过
         
-        node = base_tree_copy.find(node_name)
+        node = T_current.find(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
         
         # --- 1) 放在 node 上 ---
-        candidate_positions.append(_create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_on_node_candidate_fast_scaffold(node, new_mut))
         
         # --- 2) 新 leaf ---
-        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(node, new_mut))
         
         # --- 3) 放在每条 edge 上 ---
         for child in node.children:
             if child.name in all_path_nodes:  # 只考虑路径上的子节点
-                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(base_tree_copy, node, child, new_mut))
+                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(node, child, new_mut))
         
         # --- 4) 新 parent merge 多个子节点 ---
         if len(node.children) >= 2:
@@ -2962,7 +2956,7 @@ def find_new_leaf_positions_for_target_node(T_current: TreeNode, new_mut: str, m
                 # 限制组合数量避免爆炸
                 for r in range(2, min(4, len(path_children) + 1)):
                     for combo in combinations(path_children, r):
-                        candidate_positions.append(_create_merge_candidate_fast_scaffold(base_tree_copy, node, combo, new_mut))
+                        candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
     logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
     
@@ -3000,40 +2994,37 @@ def find_intersection_positions_within_tree_directly_scaffold(T_current: TreeNod
     
     logger.info(f"Found {len(all_path_nodes)} path nodes for {new_mut}")
     
-    # 4. 预先创建基础树的深拷贝
-    base_tree_copy = deepcopy(T_current)
-    
     # 5. 只在这些相关节点上生成候选位置
     candidate_positions = []
     
     for node_name in all_path_nodes:
         if node_name == "ROOT":
             # 保留 ROOT 上的 on_node 类型的 position
-            node = base_tree_copy.find(node_name)
+            node = T_current.find(node_name)
             if node is None:
                 logger.warning(f"Node {node_name} not found in tree")
                 continue
             
             # 生成 ROOT 上的 on_node 类型的候选位置
-            candidate_positions.append(_create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+            candidate_positions.append(_create_on_node_candidate_fast_scaffold(node, new_mut))
             
             continue  # ROOT 的其他类型位置仍然跳过
         
-        node = base_tree_copy.find(node_name)
+        node = T_current.find(node_name)
         if node is None:
             logger.warning(f"Node {node_name} not found in tree")
             continue
         
         # --- 1) 放在 node 上 ---
-        candidate_positions.append(_create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_on_node_candidate_fast_scaffold(node, new_mut))
         
         # --- 2) 新 leaf ---
-        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(base_tree_copy, node, new_mut))
+        candidate_positions.append(_create_new_leaf_candidate_fast_scaffold(node, new_mut))
         
         # --- 3) 放在每条 edge 上 ---
         for child in node.children:
             if child.name in all_path_nodes:  # 只考虑路径上的子节点
-                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(base_tree_copy, node, child, new_mut))
+                candidate_positions.append(_create_on_edge_candidate_fast_scaffold(node, child, new_mut))
         
         # --- 4) 新 parent merge 多个子节点 ---
         if len(node.children) >= 2:
@@ -3043,7 +3034,7 @@ def find_intersection_positions_within_tree_directly_scaffold(T_current: TreeNod
                 # 限制组合数量避免爆炸
                 for r in range(2, min(4, len(path_children) + 1)):
                     for combo in combinations(path_children, r):
-                        candidate_positions.append(_create_merge_candidate_fast_scaffold(base_tree_copy, node, combo, new_mut))
+                        candidate_positions.append(_create_merge_candidate_fast_scaffold(node, combo, new_mut))
     
     logger.info(f"Generated {len(candidate_positions)} candidate positions for {new_mut}")
     return candidate_positions
@@ -3116,87 +3107,46 @@ def build_tree_parent_dict_scaffold(tree):
     return parent_dict
 
 
-def _create_on_node_candidate_fast_scaffold(base_tree_copy, node, new_mut):
+def _create_on_node_candidate_fast_scaffold(node, new_mut):
     """快速创建放在节点上的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    anchor_node = new_tree.find(node.name)
-    
-    # 替换节点逻辑
-    new_node = TreeNode(new_mut)
-    for child in anchor_node.children:
-        new_node.add_child(deepcopy(child))
-    
-    if anchor_node.parent:
-        parent = anchor_node.parent
-        for i, child in enumerate(parent.children):
-            if child.name == node.name:
-                parent.children[i] = new_node
-                new_node.parent = parent
-                break
-    else:
-        new_tree = new_node
-    
     return {
         "placement_type": "on_node",
         "anchor": node.name,
         "meta": {},
-        "nodes": _extract_nodes_info_sacffold(new_tree),
-        "edges": _extract_edges_info_scaffold(new_tree)
+        "sibling_nodes": [],
     }
 
 
-def _create_new_leaf_candidate_fast_scaffold(base_tree_copy, node, new_mut):
+def _create_new_leaf_candidate_fast_scaffold(node, new_mut):
     """快速创建新叶子的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    anchor_node = new_tree.find(node.name)
-    new_leaf = TreeNode(new_mut)
-    anchor_node.add_child(new_leaf)
-    
+    child_nodes = [child.name for child in node.children]
     return {
         "placement_type": "new_leaf",
         "anchor": node.name,
         "meta": {},
-        "nodes": _extract_nodes_info_sacffold(new_tree),
-        "edges": _extract_edges_info_scaffold(new_tree)
+        "child_nodes": child_nodes,
+        "sibling_nodes": child_nodes,
     }
 
 
-def _create_on_edge_candidate_fast_scaffold(base_tree_copy, parent_node, child_node, new_mut):
+def _create_on_edge_candidate_fast_scaffold(parent_node, child_node, new_mut):
     """快速创建放在边上的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    parent = new_tree.find(parent_node.name)
-    child = new_tree.find(child_node.name)
-    new_node = TreeNode(new_mut)
-    parent.remove_child(child)
-    parent.add_child(new_node)
-    new_node.add_child(child)
-    
     return {
         "placement_type": "on_edge",
         "anchor": parent_node.name,
         "meta": {"child": child_node.name},
-        "nodes": _extract_nodes_info_sacffold(new_tree),
-        "edges": _extract_edges_info_scaffold(new_tree)
+        "sibling_nodes": [child.name for child in parent_node.children if child.name != child_node.name],
     }
 
 
-def _create_merge_candidate_fast_scaffold(base_tree_copy, parent_node, children_combo, new_mut):
+def _create_merge_candidate_fast_scaffold(parent_node, children_combo, new_mut):
     """快速创建合并子节点的候选"""
-    new_tree = deepcopy(base_tree_copy)
-    parent = new_tree.find(parent_node.name)
-    combo_nodes = [new_tree.find(child.name) for child in children_combo]
-    new_parent = TreeNode(new_mut)
-    for cn in combo_nodes:
-        parent.remove_child(cn)
-        new_parent.add_child(cn)
-    parent.add_child(new_parent)
-    
+    merge_children = [child.name for child in children_combo]
     return {
         "placement_type": "new_parent_merge",
         "anchor": parent_node.name,
-        "meta": {"merge_children": [child.name for child in children_combo]},
-        "nodes": _extract_nodes_info_sacffold(new_tree),
-        "edges": _extract_edges_info_scaffold(new_tree)
+        "meta": {"merge_children": merge_children},
+        "sibling_nodes": [child.name for child in parent_node.children if child.name not in merge_children],
     }
 
 
@@ -3500,8 +3450,7 @@ def compute_binary_penalty_for_positions(new_mut, refined_positions, M_current, 
             imputed_vec = new_mut_bin_vector & vec_parent
             
             # 获取子节点信息
-            child_nodes = [node['name'] for node in pos['nodes'] if node['parent'] == parent]
-            child_nodes = [i for i in child_nodes if i != new_mut]
+            child_nodes = pos.get('child_nodes', [])
             
             # 确保 new_mut 与子节点互斥
             for child in child_nodes:
@@ -3532,9 +3481,7 @@ def compute_binary_penalty_for_positions(new_mut, refined_positions, M_current, 
             vec_child = M_current[child]
             
             # 获取 parent 下的所有其他 child (siblings)
-            sibling_nodes = [node['name'] for node in pos['nodes'] 
-                            if node['parent'] == parent and node['name'] != child]
-            sibling_nodes = [i for i in sibling_nodes if i != new_mut]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             # 初始化 imputed_vec：包含目标 child，且在 parent 范围内
             imputed_vec = vec_child.copy()
@@ -3579,9 +3526,7 @@ def compute_binary_penalty_for_positions(new_mut, refined_positions, M_current, 
             
             # 关键：排除所有其他 sibling 节点的细胞（互斥）
             # 获取 parent 下的所有其他 child (siblings)，不包括要合并的 children
-            sibling_nodes = [node['name'] for node in pos['nodes'] 
-                            if node['parent'] == parent and node['name'] not in merge_children]
-            sibling_nodes = [i for i in sibling_nodes if i != new_mut]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             for sibling in sibling_nodes:
                 if sibling not in M_current.columns:
@@ -3739,7 +3684,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent'] == parent and n['name'] != new_mut]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             # 获取lineage之外的所有冲突节点
             lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
@@ -3760,7 +3705,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent'] == parent and n['name'] != new_mut]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             # 获取lineage之外的所有冲突节点
             lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
@@ -3783,7 +3728,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
             vec_child = M_current[child]
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in [child,new_mut]]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             # 获取lineage之外的所有冲突节点
             lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
@@ -3810,7 +3755,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
                 vec_children |= M_current[c]
             
             # 获取直系sibling冲突节点
-            sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in merge_children+[new_mut]]
+            sibling_nodes = pos.get('sibling_nodes', [])
             
             # 获取lineage之外的所有冲突节点（排除merge_children）
             lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns, exclude_nodes=merge_children)
@@ -4357,7 +4302,7 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
         vec_parent = M_current[parent] if parent != 'ROOT' else pd.Series(1, index=M_current.index)
         
         # 获取直系sibling冲突节点
-        sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent'] == parent and n['name'] != new_mut]
+        sibling_nodes = pos.get('sibling_nodes', [])
         
         # 获取lineage之外的所有冲突节点
         lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
@@ -4383,7 +4328,7 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
         vec_child = M_current[child]
         
         # 获取直系sibling冲突节点
-        sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in [child,new_mut]]
+        sibling_nodes = pos.get('sibling_nodes', [])
         
         # 获取lineage之外的所有冲突节点
         lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns)
@@ -4413,7 +4358,7 @@ def add_new_mutation_to_tree_conflict_free(new_mut, T_current, pos, M_current, p
             vec_children |= M_current[c]
         
         # 获取直系sibling冲突节点
-        sibling_nodes = [n['name'] for n in pos['nodes'] if n['parent']==parent and n['name'] not in merge_children+[new_mut]]
+        sibling_nodes = pos.get('sibling_nodes', [])
         
         # 获取lineage之外的所有冲突节点（排除merge_children）
         lineage_conflict_nodes = get_all_conflict_nodes_outside_lineage_scaffold(parent, build_lineage_parent_dict_from_tree(T_current, anchor), M_current.columns, exclude_nodes=merge_children)

--- a/src/scaffold_builder.py
+++ b/src/scaffold_builder.py
@@ -3660,6 +3660,24 @@ def compute_bayesian_penalty_for_positions_scaffold(
     
     new_mut_bin_vector = I_selected[new_mut].replace({pd.NA: np.nan}).fillna(0).astype(int)
     new_mut_mask = _as_bool_mask(new_mut_bin_vector, M_current.index)
+    new_mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    positive_cells_cache = {}
+    children_cache = {}
+    non_root_columns = [col for col in M_current.columns if col != 'ROOT']
+
+    def get_positive_cells(column_name):
+        cached = positive_cells_cache.get(column_name)
+        if cached is None:
+            cached = set(M_current.index[M_current[column_name] == 1])
+            positive_cells_cache[column_name] = cached
+        return cached
+
+    def get_anchor_children(anchor_name):
+        cached = children_cache.get(anchor_name)
+        if cached is None:
+            cached = find_children_of_node_scaffold(anchor_name, M_current.columns, parent_dict)
+            children_cache[anchor_name] = cached
+        return cached
     
     # 计算突变的特征用于动态调整惩罚
     input_binary_vec_full = I_selected[new_mut].replace({pd.NA: np.nan})
@@ -3809,6 +3827,7 @@ def compute_bayesian_penalty_for_positions_scaffold(
                 # 获取该突变的原始数据
                 mut_input_binary_vec = I_selected[mutation].replace({pd.NA: np.nan})
                 mut_posterior_vec = P_selected[mutation]
+                chain_mutations_count += 1
                 
                 # 计算该突变在new_mut放置后的新向量
                 # 对于split_full_mutmutation_chain_mutations中的突变，如果它们在final_imputed_vec为1的细胞中当前为0或NA，需要翻转为1
@@ -3827,7 +3846,6 @@ def compute_bayesian_penalty_for_positions_scaffold(
                 )
                 
                 chain_penalty += mut_penalty
-                chain_mutations_count += 1
         
         # 总罚分 = new_mut罚分 + 完整突变链罚分
         total_chain_penalty = new_mut_penalty + chain_penalty
@@ -3845,11 +3863,17 @@ def compute_bayesian_penalty_for_positions_scaffold(
         # 添加基于intersection模式和层级的精细调整
         # -------------------------
         intersection_penalty = compute_intersection_based_penalty_scaffold(
-            new_mut, pos, intersection_nodes, M_current, I_selected, na_ratio, mut_ratio, actual_na_flip_ratio
+            new_mut, pos, intersection_nodes, M_current, I_selected, na_ratio, mut_ratio, actual_na_flip_ratio,
+            precomputed_mut_cells=new_mut_cells,
+            cell_set_cache=get_positive_cells,
+            non_root_columns=non_root_columns,
         )
         
         hierarchy_penalty = compute_hierarchy_penalty_scaffold(
-            new_mut, pos, M_current, I_selected, parent_dict, na_ratio, mut_ratio, actual_na_flip_ratio
+            new_mut, pos, M_current, I_selected, parent_dict, na_ratio, mut_ratio, actual_na_flip_ratio,
+            precomputed_mut_cells=new_mut_cells,
+            cell_set_cache=get_positive_cells,
+            children_cache=get_anchor_children,
         )
         
         total_penalty = base_total_penalty + intersection_penalty + hierarchy_penalty
@@ -4104,7 +4128,19 @@ def compute_dynamic_bic_penalty_scaffold(base_φ, na_ratio, mut_ratio, actual_na
     return max(φ_adjusted, 0.1)  # 确保不会降得太低
 
 
-def compute_intersection_based_penalty_scaffold(new_mut, position, intersection_nodes, M_current, I_selected, na_ratio, mut_ratio, actual_na_flip_ratio):
+def compute_intersection_based_penalty_scaffold(
+    new_mut,
+    position,
+    intersection_nodes,
+    M_current,
+    I_selected,
+    na_ratio,
+    mut_ratio,
+    actual_na_flip_ratio,
+    precomputed_mut_cells=None,
+    cell_set_cache=None,
+    non_root_columns=None,
+):
     """
     根据intersection模式和实际NA翻转调整罚分
     """
@@ -4113,15 +4149,22 @@ def compute_intersection_based_penalty_scaffold(new_mut, position, intersection_
     anchor = position['anchor']
     
     # 获取new_mut的mutant cells
-    mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    mut_cells = precomputed_mut_cells
+    if mut_cells is None:
+        mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
     
     if placement_type == 'on_node':
-        anchor_cells = set(M_current.index[M_current[anchor] == 1])
+        if cell_set_cache is not None:
+            anchor_cells = cell_set_cache(anchor)
+        else:
+            anchor_cells = set(M_current.index[M_current[anchor] == 1])
         
         # 情况1：如果new_mut只与一个节点强相交，但被放在不同的early node
         if len(intersection_nodes) == 1:
             sole_intersection = list(intersection_nodes)[0]
-            if anchor != sole_intersection and anchor in [n for n in M_current.columns if n != 'ROOT']:
+            if non_root_columns is None:
+                non_root_columns = [n for n in M_current.columns if n != 'ROOT']
+            if anchor != sole_intersection and anchor in non_root_columns:
                 # 结合实际翻转比例调整惩罚
                 flip_based_multiplier = 1.0 + actual_na_flip_ratio  # 翻转越多，惩罚越重
                 extra_penalty += np.log(len(M_current.columns)) * 0.8 * flip_based_multiplier
@@ -4150,8 +4193,19 @@ def compute_intersection_based_penalty_scaffold(new_mut, position, intersection_
     return extra_penalty
 
 
-def compute_hierarchy_penalty_scaffold(new_mut, position, M_current, I_selected, parent_dict, 
-                            na_ratio, mut_ratio, actual_na_flip_ratio):
+def compute_hierarchy_penalty_scaffold(
+    new_mut,
+    position,
+    M_current,
+    I_selected,
+    parent_dict,
+    na_ratio,
+    mut_ratio,
+    actual_na_flip_ratio,
+    precomputed_mut_cells=None,
+    cell_set_cache=None,
+    children_cache=None,
+):
     """
     计算层级合理性惩罚，考虑实际NA翻转
     """
@@ -4159,19 +4213,30 @@ def compute_hierarchy_penalty_scaffold(new_mut, position, M_current, I_selected,
     placement_type = position['placement_type']
     anchor = position['anchor']
     
-    mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
+    mut_cells = precomputed_mut_cells
+    if mut_cells is None:
+        mut_cells = set(I_selected.index[I_selected[new_mut].fillna(0) == 1])
     
     if placement_type == 'on_node':
-        anchor_cells = set(M_current.index[M_current[anchor] == 1])
+        if cell_set_cache is not None:
+            anchor_cells = cell_set_cache(anchor)
+        else:
+            anchor_cells = set(M_current.index[M_current[anchor] == 1])
         
         # 检查这个anchor是否有children
-        anchor_children = find_children_of_node_scaffold(anchor, M_current.columns, parent_dict)
+        if children_cache is not None:
+            anchor_children = children_cache(anchor)
+        else:
+            anchor_children = find_children_of_node_scaffold(anchor, M_current.columns, parent_dict)
         
         if anchor_children:
             # 如果anchor有children，且new_mut与children有特定模式
             children_intersection = False
             for child in anchor_children:
-                child_cells = set(M_current.index[M_current[child] == 1])
+                if cell_set_cache is not None:
+                    child_cells = cell_set_cache(child)
+                else:
+                    child_cells = set(M_current.index[M_current[child] == 1])
                 if mut_cells.issubset(child_cells) and len(mut_cells) < len(child_cells) * 0.8:
                     children_intersection = True
                     break
@@ -4183,7 +4248,10 @@ def compute_hierarchy_penalty_scaffold(new_mut, position, M_current, I_selected,
     
     elif placement_type == 'new_leaf':
         parent = anchor
-        parent_cells = set(M_current.index[M_current[parent] == 1])
+        if cell_set_cache is not None:
+            parent_cells = cell_set_cache(parent)
+        else:
+            parent_cells = set(M_current.index[M_current[parent] == 1])
         
         # 如果new_mut的细胞是parent细胞的真子集，这是一个合理的子克隆
         if mut_cells.issubset(parent_cells) and len(mut_cells) < len(parent_cells) * 0.8:


### PR DESCRIPTION
1. Step1: load data and preprocessing acceleration
- Refactored allele-count parsing in `data_loader.py` into block-based processing and introduced multi-threaded parsing in `derive_MCA_from_reads()` to speed up the load-data stage on large mutation matrices.
- Added `--load_workers` so Step1 parsing parallelism can be tuned based on available CPU resources.
- Added `lru_cache` for repeated allele-string parsing to reduce redundant conversion overhead.
- Reworked Step1 matrix export to use numpy-backed TSV writing instead of heavier pandas write paths, and added `--export_workers` for parallel export of derived matrices.
- Built bulk input directly from parsed `A/C` count matrices to avoid unnecessary repeated conversions.

2. Step4: scaffold builder hot-path optimization
- Added caches around repeated tree and matrix lookups, including intersection nodes, parent dictionaries, node lookup tables, positive-cell sets, child lookup, lineage/conflict lookup, full mutation-chain lookup, and node-split parsing.
- Reduced repeated tree traversal and repeated `DataFrame/Series` access during candidate-position generation and penalty evaluation.
- Replaced heavy full-object bookkeeping with lighter metadata where safe, while keeping the original decision flow unchanged.
- Optimized `compute_bayesian_penalty_for_positions_scaffold()` without changing selection behavior:
  - preserved original candidate traversal order
  - preserved original comparison rule for best position selection
  - preserved original placement logic and tie behavior
- Pushed the chain-penalty inner loop from `pandas Series.copy()` plus per-cell iteration down to numpy mask-based slicing, with cached array access for `M_current[node]` and `I_selected[mutation]`, which significantly reduced scoring overhead.

3. Step6 / Step6.6: attachment-path and re-attachment optimization
- Refactored the Step6 Bayesian scoring path so lineage-fill side effects are returned as lightweight metadata and applied by the caller, reducing unnecessary in-function mutation and copy cost.
- Reused cached tree state and matrix-derived structures across attachment and rescue flows to reduce repeated rebuilds and repeated deep-copy overhead.
- Optimized subtree/external-mutation processing by delaying snapshots and reusing parent/lookup/intersection cache data where possible.
- Replaced several older pandas-style per-column / per-cell loops in Step6.6 with numpy-vectorized implementations for across-tree FP/FN-related recomputation.
- Fixed pandas `FutureWarning` cases caused by bitwise operations on misaligned non-boolean Series by switching those paths to aligned boolean / ndarray handling, improving robustness and cleaning up console output.